### PR TITLE
feat: Map /commands to Claude commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ data/
 
 **/.env
 **/.ccpa
+
+# Worktrees
+.worktrees/

--- a/examples/basic/.claude/commands/complex-test.md
+++ b/examples/basic/.claude/commands/complex-test.md
@@ -1,0 +1,11 @@
+---
+description: Test command with complex frontmatter
+author: QA Agent
+version: 1.0
+extra_field: should be ignored
+---
+
+# Complex Test Command
+
+This command tests frontmatter parsing with multiple fields.
+Only the description should be extracted.

--- a/examples/basic/.claude/commands/no-frontmatter.md
+++ b/examples/basic/.claude/commands/no-frontmatter.md
@@ -1,0 +1,4 @@
+# No Frontmatter Command
+
+This command has no frontmatter at all.
+The system should handle this gracefully.

--- a/examples/basic/.claude/commands/test-command.md
+++ b/examples/basic/.claude/commands/test-command.md
@@ -1,0 +1,10 @@
+---
+description: A simple test command for QA verification
+---
+
+# Test Command
+
+This is a test command for verifying the dynamic command mapping feature.
+When users type /test-command, this command should be executed.
+
+Please respond with "Test command executed successfully!"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
     "typecheck": "tsc --noEmit",
     "lint": "biome check src",
     "lint:fix": "biome check --write src",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "test:ui": "vitest --ui",
+    "test:coverage": "vitest run --coverage",
     "prepublishOnly": "pnpm run build",
     "prepare": "husky"
   },
@@ -46,9 +50,11 @@
   "devDependencies": {
     "@biomejs/biome": "^2.3.11",
     "@types/node": "^25.0.8",
+    "@vitest/ui": "^4.0.18",
     "husky": "^9.1.7",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.18"
   },
   "engines": {
     "node": ">=18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@types/node':
         specifier: ^25.0.8
         version: 25.0.8
+      '@vitest/ui':
+        specifier: ^4.0.18
+        version: 4.0.18(vitest@4.0.18)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -39,6 +42,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@25.0.8)(@vitest/ui@4.0.18)(tsx@4.21.0)
 
 packages:
 
@@ -254,6 +260,9 @@ packages:
   '@grammyjs/types@3.23.0':
     resolution: {integrity: sha512-D3jQ4UWERPsyR3op/YFudMMIPNTU47vy7L51uO9/73tMELmjO/+LX5N36/Y0CG5IQfIsz43MxiHI5rgsK0/k+g==}
 
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -269,12 +278,190 @@ packages:
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@rollup/rollup-android-arm-eabi@4.59.0':
+    resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.59.0':
+    resolution: {integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.59.0':
+    resolution: {integrity: sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.59.0':
+    resolution: {integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.59.0':
+    resolution: {integrity: sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    resolution: {integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
+    resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.59.0':
+    resolution: {integrity: sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    resolution: {integrity: sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    resolution: {integrity: sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
+    resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
   '@types/node@25.0.8':
     resolution: {integrity: sha512-powIePYMmC3ibL0UJ2i2s0WIbq6cg6UyVFQxSCpaPxxzAaziRfimGivjdF943sSGV6RADVbk0Nvlm5P/FB44Zg==}
+
+  '@vitest/expect@4.0.18':
+    resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
+
+  '@vitest/mocker@4.0.18':
+    resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.0.18':
+    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
+
+  '@vitest/runner@4.0.18':
+    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
+
+  '@vitest/snapshot@4.0.18':
+    resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
+
+  '@vitest/spy@4.0.18':
+    resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
+
+  '@vitest/ui@4.0.18':
+    resolution: {integrity: sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==}
+    peerDependencies:
+      vitest: 4.0.18
+
+  '@vitest/utils@4.0.18':
+    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
@@ -283,6 +470,10 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -301,10 +492,16 @@ packages:
     resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
     engines: {node: '>=12'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   esbuild@0.27.2:
     resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
@@ -314,6 +511,10 @@ packages:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
 
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
@@ -321,9 +522,24 @@ packages:
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  flatted@3.3.4:
+    resolution: {integrity: sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -373,6 +589,9 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
@@ -388,8 +607,17 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
 
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -408,6 +636,9 @@ packages:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
@@ -420,9 +651,19 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
 
   pino-abstract-transport@3.0.0:
     resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
@@ -433,6 +674,10 @@ packages:
   pino@10.2.0:
     resolution: {integrity: sha512-NFnZqUliT+OHkRXVSf8vdOr13N1wv31hRryVjqbreVh/SDCNaI6mnRDDq89HVRCbem1SAl7yj04OANeqP0nT6A==}
     hasBin: true
+
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+    engines: {node: ^10 || ^12 || >=14}
 
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
@@ -458,6 +703,11 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rollup@4.59.0:
+    resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -477,15 +727,32 @@ packages:
     resolution: {integrity: sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==}
     engines: {node: '>=18'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
 
   sonic-boom@4.2.0:
     resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
 
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
@@ -495,9 +762,28 @@ packages:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
     engines: {node: '>=20'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.0.2:
+    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.0.3:
+    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
@@ -515,6 +801,80 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
+  vite@7.3.1:
+    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.0.18:
+    resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.0.18
+      '@vitest/browser-preview': 4.0.18
+      '@vitest/browser-webdriverio': 4.0.18
+      '@vitest/ui': 4.0.18
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -524,6 +884,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   zod@4.3.5:
@@ -646,6 +1011,8 @@ snapshots:
 
   '@grammyjs/types@3.23.0': {}
 
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -660,19 +1027,161 @@ snapshots:
 
   '@pinojs/redact@0.4.0': {}
 
+  '@polka/url@1.0.0-next.29': {}
+
+  '@rollup/rollup-android-arm-eabi@4.59.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
+    optional: true
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
   '@types/node@25.0.8':
     dependencies:
       undici-types: 7.16.0
 
+  '@vitest/expect@4.0.18':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      chai: 6.2.2
+      tinyrainbow: 3.0.3
+
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.0.8)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@25.0.8)(tsx@4.21.0)
+
+  '@vitest/pretty-format@4.0.18':
+    dependencies:
+      tinyrainbow: 3.0.3
+
+  '@vitest/runner@4.0.18':
+    dependencies:
+      '@vitest/utils': 4.0.18
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.0.18': {}
+
+  '@vitest/ui@4.0.18(vitest@4.0.18)':
+    dependencies:
+      '@vitest/utils': 4.0.18
+      fflate: 0.8.2
+      flatted: 3.3.4
+      pathe: 2.0.3
+      sirv: 3.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vitest: 4.0.18(@types/node@25.0.8)(@vitest/ui@4.0.18)(tsx@4.21.0)
+
+  '@vitest/utils@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      tinyrainbow: 3.0.3
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
+
+  assertion-error@2.0.1: {}
 
   atomic-sleep@1.0.0: {}
 
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  chai@6.2.2: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -685,6 +1194,8 @@ snapshots:
       ms: 2.1.3
 
   dotenv@17.2.3: {}
+
+  es-module-lexer@1.7.0: {}
 
   esbuild@0.27.2:
     optionalDependencies:
@@ -715,6 +1226,10 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.2
       '@esbuild/win32-x64': 0.27.2
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   event-target-shim@5.0.1: {}
 
   execa@5.1.1:
@@ -729,6 +1244,8 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
+  expect-type@1.3.0: {}
+
   fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -741,9 +1258,17 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fflate@0.8.2: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  flatted@3.3.4: {}
 
   fsevents@2.3.3:
     optional: true
@@ -784,6 +1309,10 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
@@ -795,7 +1324,11 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
+  mrmime@2.0.1: {}
+
   ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
 
   node-fetch@2.7.0:
     dependencies:
@@ -810,6 +1343,8 @@ snapshots:
     dependencies:
       path-key: 3.1.1
 
+  obug@2.1.1: {}
+
   on-exit-leak-free@2.1.2: {}
 
   onetime@5.1.2:
@@ -818,7 +1353,13 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
   picomatch@2.3.1: {}
+
+  picomatch@4.0.3: {}
 
   pino-abstract-transport@3.0.0:
     dependencies:
@@ -840,6 +1381,12 @@ snapshots:
       sonic-boom: 4.2.0
       thread-stream: 4.0.0
 
+  postcss@8.5.8:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   process-warning@5.0.0: {}
 
   queue-microtask@1.2.3: {}
@@ -853,6 +1400,37 @@ snapshots:
   resolve-pkg-maps@1.0.0: {}
 
   reusify@1.1.0: {}
+
+  rollup@4.59.0:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.59.0
+      '@rollup/rollup-android-arm64': 4.59.0
+      '@rollup/rollup-darwin-arm64': 4.59.0
+      '@rollup/rollup-darwin-x64': 4.59.0
+      '@rollup/rollup-freebsd-arm64': 4.59.0
+      '@rollup/rollup-freebsd-x64': 4.59.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.59.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.59.0
+      '@rollup/rollup-linux-arm64-gnu': 4.59.0
+      '@rollup/rollup-linux-arm64-musl': 4.59.0
+      '@rollup/rollup-linux-loong64-gnu': 4.59.0
+      '@rollup/rollup-linux-loong64-musl': 4.59.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.59.0
+      '@rollup/rollup-linux-ppc64-musl': 4.59.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.59.0
+      '@rollup/rollup-linux-riscv64-musl': 4.59.0
+      '@rollup/rollup-linux-s390x-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-musl': 4.59.0
+      '@rollup/rollup-openbsd-x64': 4.59.0
+      '@rollup/rollup-openharmony-arm64': 4.59.0
+      '@rollup/rollup-win32-arm64-msvc': 4.59.0
+      '@rollup/rollup-win32-ia32-msvc': 4.59.0
+      '@rollup/rollup-win32-x64-gnu': 4.59.0
+      '@rollup/rollup-win32-x64-msvc': 4.59.0
+      fsevents: 2.3.3
 
   run-parallel@1.2.0:
     dependencies:
@@ -871,13 +1449,27 @@ snapshots:
       execa: 5.1.1
       fast-glob: 3.3.3
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
+
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
 
   sonic-boom@4.2.0:
     dependencies:
       atomic-sleep: 1.0.0
 
+  source-map-js@1.2.1: {}
+
   split2@4.2.0: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   strip-final-newline@2.0.0: {}
 
@@ -885,9 +1477,22 @@ snapshots:
     dependencies:
       real-require: 0.2.0
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.0.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tinyrainbow@3.0.3: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  totalist@3.0.1: {}
 
   tr46@0.0.3: {}
 
@@ -902,6 +1507,57 @@ snapshots:
 
   undici-types@7.16.0: {}
 
+  vite@7.3.1(@types/node@25.0.8)(tsx@4.21.0):
+    dependencies:
+      esbuild: 0.27.2
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.8
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 25.0.8
+      fsevents: 2.3.3
+      tsx: 4.21.0
+
+  vitest@4.0.18(@types/node@25.0.8)(@vitest/ui@4.0.18)(tsx@4.21.0):
+    dependencies:
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.0.8)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.1(@types/node@25.0.8)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.0.8
+      '@vitest/ui': 4.0.18(vitest@4.0.18)
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
   webidl-conversions@3.0.1: {}
 
   whatwg-url@5.0.0:
@@ -912,5 +1568,10 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   zod@4.3.5: {}

--- a/src/__tests__/basic.test.ts
+++ b/src/__tests__/basic.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+
+describe('Testing Framework Verification', () => {
+  it('should run basic test successfully', () => {
+    expect(2 + 2).toBe(4);
+  });
+
+  it('should handle async operations', async () => {
+    const result = await Promise.resolve('test');
+    expect(result).toBe('test');
+  });
+
+  it('should work with Date objects (timestamp validation)', () => {
+    const timestamp = 1709520000;
+    const date = new Date(timestamp * 1000);
+    const isoString = date.toISOString();
+
+    expect(isoString).toBe('2024-03-04T02:40:00.000Z');
+    expect(timestamp).toBe(1709520000);
+  });
+});

--- a/src/__tests__/basic.test.ts
+++ b/src/__tests__/basic.test.ts
@@ -1,21 +1,21 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from "vitest";
 
-describe('Testing Framework Verification', () => {
-  it('should run basic test successfully', () => {
+describe("Testing Framework Verification", () => {
+  it("should run basic test successfully", () => {
     expect(2 + 2).toBe(4);
   });
 
-  it('should handle async operations', async () => {
-    const result = await Promise.resolve('test');
-    expect(result).toBe('test');
+  it("should handle async operations", async () => {
+    const result = await Promise.resolve("test");
+    expect(result).toBe("test");
   });
 
-  it('should work with Date objects (timestamp validation)', () => {
+  it("should work with Date objects (timestamp validation)", () => {
     const timestamp = 1709520000;
     const date = new Date(timestamp * 1000);
     const isoString = date.toISOString();
 
-    expect(isoString).toBe('2024-03-04T02:40:00.000Z');
+    expect(isoString).toBe("2024-03-04T02:40:00.000Z");
     expect(timestamp).toBe(1709520000);
   });
 });

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,6 +1,7 @@
 import { execSync } from "node:child_process";
 import { Bot } from "grammy";
 import { clearHandler } from "./bot/commands/clear.js";
+import { registerDynamicCommands } from "./bot/commands/dynamic.js";
 import { helpHandler } from "./bot/commands/help.js";
 import { startHandler } from "./bot/commands/start.js";
 import {
@@ -57,10 +58,13 @@ export async function startBot(): Promise<void> {
   bot.use(authMiddleware);
   bot.use(rateLimitMiddleware);
 
-  // Register commands
+  // Register built-in commands
   bot.command("start", startHandler);
   bot.command("help", helpHandler);
   bot.command("clear", clearHandler);
+
+  // Register dynamic Claude commands
+  await registerDynamicCommands(bot);
 
   // Text message handler
   bot.on("message:text", textHandler);

--- a/src/bot/__tests__/commands.dynamic.test.ts
+++ b/src/bot/__tests__/commands.dynamic.test.ts
@@ -1,16 +1,19 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { Bot, Context } from 'grammy';
-import { registerDynamicCommands, getDynamicCommandsHelp } from '../commands/dynamic.js';
-import { discoverClaudeCommands } from '../../claude/commands.js';
-import { executeClaudeCommand } from '../../claude/commandExecutor.js';
-import { getLogger } from '../../logger.js';
+import type { Bot, Context } from "grammy";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { executeClaudeCommand } from "../../claude/commandExecutor.js";
+import { discoverClaudeCommands } from "../../claude/commands.js";
+import { getLogger } from "../../logger.js";
+import {
+  getDynamicCommandsHelp,
+  registerDynamicCommands,
+} from "../commands/dynamic.js";
 
 // Mock dependencies
-vi.mock('../../claude/commands.js');
-vi.mock('../../claude/commandExecutor.js');
-vi.mock('../../logger.js');
+vi.mock("../../claude/commands.js");
+vi.mock("../../claude/commandExecutor.js");
+vi.mock("../../logger.js");
 
-describe('Dynamic Commands - Registration and Help', () => {
+describe("Dynamic Commands - Registration and Help", () => {
   let mockBot: Bot;
   let mockContext: Context;
 
@@ -25,7 +28,7 @@ describe('Dynamic Commands - Registration and Help', () => {
     // Mock context
     mockContext = {
       message: {
-        text: '/test-command arg1 arg2',
+        text: "/test-command arg1 arg2",
       },
     } as unknown as Context;
 
@@ -45,20 +48,20 @@ describe('Dynamic Commands - Registration and Help', () => {
     vi.resetAllMocks();
   });
 
-  describe('registerDynamicCommands', () => {
-    it('should register discovered commands with the bot', async () => {
+  describe("registerDynamicCommands", () => {
+    it("should register discovered commands with the bot", async () => {
       const mockCommands = [
         {
-          name: 'test-command',
-          filePath: '/test/commands/test-command.md',
-          description: 'A test command',
-          content: '# Test Command',
+          name: "test-command",
+          filePath: "/test/commands/test-command.md",
+          description: "A test command",
+          content: "# Test Command",
         },
         {
-          name: 'another-command',
-          filePath: '/test/commands/another-command.md',
-          description: 'Another test command',
-          content: '# Another Command',
+          name: "another-command",
+          filePath: "/test/commands/another-command.md",
+          description: "Another test command",
+          content: "# Another Command",
         },
       ];
 
@@ -68,37 +71,43 @@ describe('Dynamic Commands - Registration and Help', () => {
 
       // Verify bot.command was called for each discovered command
       expect(mockBot.command).toHaveBeenCalledTimes(2);
-      expect(mockBot.command).toHaveBeenCalledWith('test-command', expect.any(Function));
-      expect(mockBot.command).toHaveBeenCalledWith('another-command', expect.any(Function));
+      expect(mockBot.command).toHaveBeenCalledWith(
+        "test-command",
+        expect.any(Function),
+      );
+      expect(mockBot.command).toHaveBeenCalledWith(
+        "another-command",
+        expect.any(Function),
+      );
 
       // Verify logging
       expect(getLogger().debug).toHaveBeenCalledWith(
         expect.objectContaining({
-          commandName: 'test-command',
-          description: 'A test command',
+          commandName: "test-command",
+          description: "A test command",
         }),
-        'Registered dynamic Claude command'
+        "Registered dynamic Claude command",
       );
 
       expect(getLogger().info).toHaveBeenCalledWith(
         { count: 2 },
-        'Registered dynamic Claude commands'
+        "Registered dynamic Claude commands",
       );
     });
 
-    it('should handle no commands found', async () => {
+    it("should handle no commands found", async () => {
       vi.mocked(discoverClaudeCommands).mockResolvedValue([]);
 
       await registerDynamicCommands(mockBot);
 
       expect(mockBot.command).not.toHaveBeenCalled();
       expect(getLogger().debug).toHaveBeenCalledWith(
-        'No Claude commands found to register'
+        "No Claude commands found to register",
       );
     });
 
-    it('should handle registration errors gracefully', async () => {
-      const error = new Error('Registration failed');
+    it("should handle registration errors gracefully", async () => {
+      const error = new Error("Registration failed");
       vi.mocked(discoverClaudeCommands).mockRejectedValue(error);
 
       await registerDynamicCommands(mockBot);
@@ -106,17 +115,17 @@ describe('Dynamic Commands - Registration and Help', () => {
       expect(mockBot.command).not.toHaveBeenCalled();
       expect(getLogger().error).toHaveBeenCalledWith(
         { error },
-        'Failed to register dynamic commands'
+        "Failed to register dynamic commands",
       );
     });
 
-    it('should create proper command handlers', async () => {
+    it("should create proper command handlers", async () => {
       const mockCommands = [
         {
-          name: 'test-command',
-          filePath: '/test/commands/test-command.md',
-          description: 'A test command',
-          content: '# Test Command',
+          name: "test-command",
+          filePath: "/test/commands/test-command.md",
+          description: "A test command",
+          content: "# Test Command",
         },
       ];
 
@@ -128,13 +137,13 @@ describe('Dynamic Commands - Registration and Help', () => {
       const handlerCall = vi.mocked(mockBot.command).mock.calls[0];
       const [commandName, handler] = handlerCall;
 
-      expect(commandName).toBe('test-command');
+      expect(commandName).toBe("test-command");
       expect(handler).toBeInstanceOf(Function);
 
       // Test the handler
       const mockCtx = {
         message: {
-          text: '/test-command arg1 arg2 arg3',
+          text: "/test-command arg1 arg2 arg3",
         },
       } as unknown as Context;
 
@@ -142,18 +151,18 @@ describe('Dynamic Commands - Registration and Help', () => {
 
       expect(executeClaudeCommand).toHaveBeenCalledWith(
         mockCtx,
-        'test-command',
-        'arg1 arg2 arg3'
+        "test-command",
+        "arg1 arg2 arg3",
       );
     });
 
-    it('should handle command with no arguments', async () => {
+    it("should handle command with no arguments", async () => {
       const mockCommands = [
         {
-          name: 'test-command',
-          filePath: '/test/commands/test-command.md',
-          description: 'A test command',
-          content: '# Test Command',
+          name: "test-command",
+          filePath: "/test/commands/test-command.md",
+          description: "A test command",
+          content: "# Test Command",
         },
       ];
 
@@ -167,7 +176,7 @@ describe('Dynamic Commands - Registration and Help', () => {
       // Test handler with no arguments
       const mockCtx = {
         message: {
-          text: '/test-command',
+          text: "/test-command",
         },
       } as unknown as Context;
 
@@ -175,18 +184,18 @@ describe('Dynamic Commands - Registration and Help', () => {
 
       expect(executeClaudeCommand).toHaveBeenCalledWith(
         mockCtx,
-        'test-command',
-        undefined
+        "test-command",
+        undefined,
       );
     });
 
-    it('should handle command with only whitespace arguments', async () => {
+    it("should handle command with only whitespace arguments", async () => {
       const mockCommands = [
         {
-          name: 'test-command',
-          filePath: '/test/commands/test-command.md',
-          description: 'A test command',
-          content: '# Test Command',
+          name: "test-command",
+          filePath: "/test/commands/test-command.md",
+          description: "A test command",
+          content: "# Test Command",
         },
       ];
 
@@ -200,7 +209,7 @@ describe('Dynamic Commands - Registration and Help', () => {
       // Test handler with whitespace-only arguments
       const mockCtx = {
         message: {
-          text: '/test-command   \t  \n  ',
+          text: "/test-command   \t  \n  ",
         },
       } as unknown as Context;
 
@@ -208,18 +217,18 @@ describe('Dynamic Commands - Registration and Help', () => {
 
       expect(executeClaudeCommand).toHaveBeenCalledWith(
         mockCtx,
-        'test-command',
-        undefined
+        "test-command",
+        undefined,
       );
     });
 
-    it('should handle missing message text', async () => {
+    it("should handle missing message text", async () => {
       const mockCommands = [
         {
-          name: 'test-command',
-          filePath: '/test/commands/test-command.md',
-          description: 'A test command',
-          content: '# Test Command',
+          name: "test-command",
+          filePath: "/test/commands/test-command.md",
+          description: "A test command",
+          content: "# Test Command",
         },
       ];
 
@@ -239,32 +248,32 @@ describe('Dynamic Commands - Registration and Help', () => {
 
       expect(executeClaudeCommand).toHaveBeenCalledWith(
         mockCtx,
-        'test-command',
-        undefined
+        "test-command",
+        undefined,
       );
     });
   });
 
-  describe('getDynamicCommandsHelp', () => {
-    it('should generate help text for discovered commands', async () => {
+  describe("getDynamicCommandsHelp", () => {
+    it("should generate help text for discovered commands", async () => {
       const mockCommands = [
         {
-          name: 'test-command',
-          filePath: '/test/commands/test-command.md',
-          description: 'A test command for testing',
-          content: '# Test Command',
+          name: "test-command",
+          filePath: "/test/commands/test-command.md",
+          description: "A test command for testing",
+          content: "# Test Command",
         },
         {
-          name: 'help-me',
-          filePath: '/test/commands/help-me.md',
-          description: 'Gets help with tasks',
-          content: '# Help Command',
+          name: "help-me",
+          filePath: "/test/commands/help-me.md",
+          description: "Gets help with tasks",
+          content: "# Help Command",
         },
         {
-          name: 'no-description',
-          filePath: '/test/commands/no-description.md',
+          name: "no-description",
+          filePath: "/test/commands/no-description.md",
           description: undefined,
-          content: '# No Description',
+          content: "# No Description",
         },
       ];
 
@@ -281,21 +290,21 @@ describe('Dynamic Commands - Registration and Help', () => {
       expect(help).toBe(expectedHelp);
     });
 
-    it('should return empty string when no commands found', async () => {
+    it("should return empty string when no commands found", async () => {
       vi.mocked(discoverClaudeCommands).mockResolvedValue([]);
 
       const help = await getDynamicCommandsHelp();
 
-      expect(help).toBe('');
+      expect(help).toBe("");
     });
 
-    it('should handle commands with empty descriptions', async () => {
+    it("should handle commands with empty descriptions", async () => {
       const mockCommands = [
         {
-          name: 'empty-desc',
-          filePath: '/test/commands/empty-desc.md',
-          description: '',
-          content: '# Empty Description',
+          name: "empty-desc",
+          filePath: "/test/commands/empty-desc.md",
+          description: "",
+          content: "# Empty Description",
         },
       ];
 
@@ -308,26 +317,26 @@ describe('Dynamic Commands - Registration and Help', () => {
 `);
     });
 
-    it('should handle discovery errors gracefully', async () => {
-      const error = new Error('Discovery failed');
+    it("should handle discovery errors gracefully", async () => {
+      const error = new Error("Discovery failed");
       vi.mocked(discoverClaudeCommands).mockRejectedValue(error);
 
       const help = await getDynamicCommandsHelp();
 
-      expect(help).toBe('');
+      expect(help).toBe("");
       expect(getLogger().error).toHaveBeenCalledWith(
         { error },
-        'Failed to get dynamic commands help'
+        "Failed to get dynamic commands help",
       );
     });
 
-    it('should handle commands with special characters in descriptions', async () => {
+    it("should handle commands with special characters in descriptions", async () => {
       const mockCommands = [
         {
-          name: 'special-chars',
-          filePath: '/test/commands/special-chars.md',
-          description: 'Command with *markdown* and _special_ chars!',
-          content: '# Special Chars',
+          name: "special-chars",
+          filePath: "/test/commands/special-chars.md",
+          description: "Command with *markdown* and _special_ chars!",
+          content: "# Special Chars",
         },
       ];
 
@@ -340,15 +349,16 @@ describe('Dynamic Commands - Registration and Help', () => {
 `);
     });
 
-    it('should handle very long command descriptions', async () => {
-      const longDescription = 'This is a very long command description that exceeds normal length expectations and might cause formatting issues in some interfaces but should be handled gracefully';
+    it("should handle very long command descriptions", async () => {
+      const longDescription =
+        "This is a very long command description that exceeds normal length expectations and might cause formatting issues in some interfaces but should be handled gracefully";
 
       const mockCommands = [
         {
-          name: 'long-desc',
-          filePath: '/test/commands/long-desc.md',
+          name: "long-desc",
+          filePath: "/test/commands/long-desc.md",
           description: longDescription,
-          content: '# Long Description',
+          content: "# Long Description",
         },
       ];
 
@@ -362,14 +372,14 @@ describe('Dynamic Commands - Registration and Help', () => {
     });
   });
 
-  describe('Command Argument Parsing', () => {
-    it('should correctly parse simple arguments', async () => {
+  describe("Command Argument Parsing", () => {
+    it("should correctly parse simple arguments", async () => {
       const mockCommands = [
         {
-          name: 'test-cmd',
-          filePath: '/test/commands/test-cmd.md',
-          description: 'Test command',
-          content: '# Test',
+          name: "test-cmd",
+          filePath: "/test/commands/test-cmd.md",
+          description: "Test command",
+          content: "# Test",
         },
       ];
 
@@ -380,12 +390,15 @@ describe('Dynamic Commands - Registration and Help', () => {
       const [, handler] = handlerCall;
 
       const testCases = [
-        { text: '/test-cmd hello world', expectedArgs: 'hello world' },
-        { text: '/test-cmd single', expectedArgs: 'single' },
-        { text: '/test-cmd', expectedArgs: undefined },
-        { text: '/test-cmd   spaced   args   ', expectedArgs: 'spaced   args' },
-        { text: '/test-cmd "quoted argument"', expectedArgs: '"quoted argument"' },
-        { text: '/test-cmd --flag value', expectedArgs: '--flag value' },
+        { text: "/test-cmd hello world", expectedArgs: "hello world" },
+        { text: "/test-cmd single", expectedArgs: "single" },
+        { text: "/test-cmd", expectedArgs: undefined },
+        { text: "/test-cmd   spaced   args   ", expectedArgs: "spaced   args" },
+        {
+          text: '/test-cmd "quoted argument"',
+          expectedArgs: '"quoted argument"',
+        },
+        { text: "/test-cmd --flag value", expectedArgs: "--flag value" },
       ];
 
       for (const testCase of testCases) {
@@ -399,49 +412,57 @@ describe('Dynamic Commands - Registration and Help', () => {
 
         expect(executeClaudeCommand).toHaveBeenCalledWith(
           mockCtx,
-          'test-cmd',
-          testCase.expectedArgs
+          "test-cmd",
+          testCase.expectedArgs,
         );
       }
     });
 
-    it('should handle commands with hyphens and underscores', async () => {
+    it("should handle commands with hyphens and underscores", async () => {
       const mockCommands = [
         {
-          name: 'multi-word-command',
-          filePath: '/test/commands/multi-word-command.md',
-          description: 'Multi word command',
-          content: '# Multi Word',
+          name: "multi-word-command",
+          filePath: "/test/commands/multi-word-command.md",
+          description: "Multi word command",
+          content: "# Multi Word",
         },
         {
-          name: 'snake_case_command',
-          filePath: '/test/commands/snake_case_command.md',
-          description: 'Snake case command',
-          content: '# Snake Case',
+          name: "snake_case_command",
+          filePath: "/test/commands/snake_case_command.md",
+          description: "Snake case command",
+          content: "# Snake Case",
         },
       ];
 
       vi.mocked(discoverClaudeCommands).mockResolvedValue(mockCommands);
       await registerDynamicCommands(mockBot);
 
-      expect(mockBot.command).toHaveBeenCalledWith('multi-word-command', expect.any(Function));
-      expect(mockBot.command).toHaveBeenCalledWith('snake_case_command', expect.any(Function));
+      expect(mockBot.command).toHaveBeenCalledWith(
+        "multi-word-command",
+        expect.any(Function),
+      );
+      expect(mockBot.command).toHaveBeenCalledWith(
+        "snake_case_command",
+        expect.any(Function),
+      );
     });
   });
 
-  describe('Error Handling and Edge Cases', () => {
-    it('should handle executeClaudeCommand failures gracefully', async () => {
+  describe("Error Handling and Edge Cases", () => {
+    it("should handle executeClaudeCommand failures gracefully", async () => {
       const mockCommands = [
         {
-          name: 'failing-command',
-          filePath: '/test/commands/failing-command.md',
-          description: 'A command that fails',
-          content: '# Failing Command',
+          name: "failing-command",
+          filePath: "/test/commands/failing-command.md",
+          description: "A command that fails",
+          content: "# Failing Command",
         },
       ];
 
       vi.mocked(discoverClaudeCommands).mockResolvedValue(mockCommands);
-      vi.mocked(executeClaudeCommand).mockRejectedValue(new Error('Execution failed'));
+      vi.mocked(executeClaudeCommand).mockRejectedValue(
+        new Error("Execution failed"),
+      );
 
       await registerDynamicCommands(mockBot);
 
@@ -449,11 +470,11 @@ describe('Dynamic Commands - Registration and Help', () => {
       const [, handler] = handlerCall;
 
       const mockCtx = {
-        message: { text: '/failing-command test' },
+        message: { text: "/failing-command test" },
       } as unknown as Context;
 
       // Should not throw error, should handle gracefully
-      await expect(handler(mockCtx)).rejects.toThrow('Execution failed');
+      await expect(handler(mockCtx)).rejects.toThrow("Execution failed");
     });
   });
 });

--- a/src/bot/__tests__/commands.dynamic.test.ts
+++ b/src/bot/__tests__/commands.dynamic.test.ts
@@ -38,7 +38,7 @@ describe("Dynamic Commands - Registration and Help", () => {
       debug: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
-    } as any);
+    } as unknown as ReturnType<typeof getLogger>);
 
     // Mock command executor
     vi.mocked(executeClaudeCommand).mockResolvedValue(undefined);
@@ -474,7 +474,9 @@ describe("Dynamic Commands - Registration and Help", () => {
       } as unknown as Context;
 
       // Should not throw error, should handle gracefully
-      await expect((handler as (ctx: Context) => Promise<void>)(mockCtx)).rejects.toThrow("Execution failed");
+      await expect(
+        (handler as (ctx: Context) => Promise<void>)(mockCtx),
+      ).rejects.toThrow("Execution failed");
     });
   });
 });

--- a/src/bot/__tests__/commands.dynamic.test.ts
+++ b/src/bot/__tests__/commands.dynamic.test.ts
@@ -1,0 +1,459 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Bot, Context } from 'grammy';
+import { registerDynamicCommands, getDynamicCommandsHelp } from '../commands/dynamic.js';
+import { discoverClaudeCommands } from '../../claude/commands.js';
+import { executeClaudeCommand } from '../../claude/commandExecutor.js';
+import { getLogger } from '../../logger.js';
+
+// Mock dependencies
+vi.mock('../../claude/commands.js');
+vi.mock('../../claude/commandExecutor.js');
+vi.mock('../../logger.js');
+
+describe('Dynamic Commands - Registration and Help', () => {
+  let mockBot: Bot;
+  let mockContext: Context;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Mock bot
+    mockBot = {
+      command: vi.fn(),
+    } as unknown as Bot;
+
+    // Mock context
+    mockContext = {
+      message: {
+        text: '/test-command arg1 arg2',
+      },
+    } as unknown as Context;
+
+    // Mock logger
+    vi.mocked(getLogger).mockReturnValue({
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as any);
+
+    // Mock command executor
+    vi.mocked(executeClaudeCommand).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('registerDynamicCommands', () => {
+    it('should register discovered commands with the bot', async () => {
+      const mockCommands = [
+        {
+          name: 'test-command',
+          filePath: '/test/commands/test-command.md',
+          description: 'A test command',
+          content: '# Test Command',
+        },
+        {
+          name: 'another-command',
+          filePath: '/test/commands/another-command.md',
+          description: 'Another test command',
+          content: '# Another Command',
+        },
+      ];
+
+      vi.mocked(discoverClaudeCommands).mockResolvedValue(mockCommands);
+
+      await registerDynamicCommands(mockBot);
+
+      // Verify bot.command was called for each discovered command
+      expect(mockBot.command).toHaveBeenCalledTimes(2);
+      expect(mockBot.command).toHaveBeenCalledWith('test-command', expect.any(Function));
+      expect(mockBot.command).toHaveBeenCalledWith('another-command', expect.any(Function));
+
+      // Verify logging
+      expect(getLogger().debug).toHaveBeenCalledWith(
+        expect.objectContaining({
+          commandName: 'test-command',
+          description: 'A test command',
+        }),
+        'Registered dynamic Claude command'
+      );
+
+      expect(getLogger().info).toHaveBeenCalledWith(
+        { count: 2 },
+        'Registered dynamic Claude commands'
+      );
+    });
+
+    it('should handle no commands found', async () => {
+      vi.mocked(discoverClaudeCommands).mockResolvedValue([]);
+
+      await registerDynamicCommands(mockBot);
+
+      expect(mockBot.command).not.toHaveBeenCalled();
+      expect(getLogger().debug).toHaveBeenCalledWith(
+        'No Claude commands found to register'
+      );
+    });
+
+    it('should handle registration errors gracefully', async () => {
+      const error = new Error('Registration failed');
+      vi.mocked(discoverClaudeCommands).mockRejectedValue(error);
+
+      await registerDynamicCommands(mockBot);
+
+      expect(mockBot.command).not.toHaveBeenCalled();
+      expect(getLogger().error).toHaveBeenCalledWith(
+        { error },
+        'Failed to register dynamic commands'
+      );
+    });
+
+    it('should create proper command handlers', async () => {
+      const mockCommands = [
+        {
+          name: 'test-command',
+          filePath: '/test/commands/test-command.md',
+          description: 'A test command',
+          content: '# Test Command',
+        },
+      ];
+
+      vi.mocked(discoverClaudeCommands).mockResolvedValue(mockCommands);
+
+      await registerDynamicCommands(mockBot);
+
+      // Get the registered handler
+      const handlerCall = vi.mocked(mockBot.command).mock.calls[0];
+      const [commandName, handler] = handlerCall;
+
+      expect(commandName).toBe('test-command');
+      expect(handler).toBeInstanceOf(Function);
+
+      // Test the handler
+      const mockCtx = {
+        message: {
+          text: '/test-command arg1 arg2 arg3',
+        },
+      } as unknown as Context;
+
+      await handler(mockCtx);
+
+      expect(executeClaudeCommand).toHaveBeenCalledWith(
+        mockCtx,
+        'test-command',
+        'arg1 arg2 arg3'
+      );
+    });
+
+    it('should handle command with no arguments', async () => {
+      const mockCommands = [
+        {
+          name: 'test-command',
+          filePath: '/test/commands/test-command.md',
+          description: 'A test command',
+          content: '# Test Command',
+        },
+      ];
+
+      vi.mocked(discoverClaudeCommands).mockResolvedValue(mockCommands);
+
+      await registerDynamicCommands(mockBot);
+
+      const handlerCall = vi.mocked(mockBot.command).mock.calls[0];
+      const [, handler] = handlerCall;
+
+      // Test handler with no arguments
+      const mockCtx = {
+        message: {
+          text: '/test-command',
+        },
+      } as unknown as Context;
+
+      await handler(mockCtx);
+
+      expect(executeClaudeCommand).toHaveBeenCalledWith(
+        mockCtx,
+        'test-command',
+        undefined
+      );
+    });
+
+    it('should handle command with only whitespace arguments', async () => {
+      const mockCommands = [
+        {
+          name: 'test-command',
+          filePath: '/test/commands/test-command.md',
+          description: 'A test command',
+          content: '# Test Command',
+        },
+      ];
+
+      vi.mocked(discoverClaudeCommands).mockResolvedValue(mockCommands);
+
+      await registerDynamicCommands(mockBot);
+
+      const handlerCall = vi.mocked(mockBot.command).mock.calls[0];
+      const [, handler] = handlerCall;
+
+      // Test handler with whitespace-only arguments
+      const mockCtx = {
+        message: {
+          text: '/test-command   \t  \n  ',
+        },
+      } as unknown as Context;
+
+      await handler(mockCtx);
+
+      expect(executeClaudeCommand).toHaveBeenCalledWith(
+        mockCtx,
+        'test-command',
+        undefined
+      );
+    });
+
+    it('should handle missing message text', async () => {
+      const mockCommands = [
+        {
+          name: 'test-command',
+          filePath: '/test/commands/test-command.md',
+          description: 'A test command',
+          content: '# Test Command',
+        },
+      ];
+
+      vi.mocked(discoverClaudeCommands).mockResolvedValue(mockCommands);
+
+      await registerDynamicCommands(mockBot);
+
+      const handlerCall = vi.mocked(mockBot.command).mock.calls[0];
+      const [, handler] = handlerCall;
+
+      // Test handler with missing message text
+      const mockCtx = {
+        message: {},
+      } as unknown as Context;
+
+      await handler(mockCtx);
+
+      expect(executeClaudeCommand).toHaveBeenCalledWith(
+        mockCtx,
+        'test-command',
+        undefined
+      );
+    });
+  });
+
+  describe('getDynamicCommandsHelp', () => {
+    it('should generate help text for discovered commands', async () => {
+      const mockCommands = [
+        {
+          name: 'test-command',
+          filePath: '/test/commands/test-command.md',
+          description: 'A test command for testing',
+          content: '# Test Command',
+        },
+        {
+          name: 'help-me',
+          filePath: '/test/commands/help-me.md',
+          description: 'Gets help with tasks',
+          content: '# Help Command',
+        },
+        {
+          name: 'no-description',
+          filePath: '/test/commands/no-description.md',
+          description: undefined,
+          content: '# No Description',
+        },
+      ];
+
+      vi.mocked(discoverClaudeCommands).mockResolvedValue(mockCommands);
+
+      const help = await getDynamicCommandsHelp();
+
+      const expectedHelp = `*Claude Commands:*
+/test-command - A test command for testing
+/help-me - Gets help with tasks
+/no-description - No description available
+`;
+
+      expect(help).toBe(expectedHelp);
+    });
+
+    it('should return empty string when no commands found', async () => {
+      vi.mocked(discoverClaudeCommands).mockResolvedValue([]);
+
+      const help = await getDynamicCommandsHelp();
+
+      expect(help).toBe('');
+    });
+
+    it('should handle commands with empty descriptions', async () => {
+      const mockCommands = [
+        {
+          name: 'empty-desc',
+          filePath: '/test/commands/empty-desc.md',
+          description: '',
+          content: '# Empty Description',
+        },
+      ];
+
+      vi.mocked(discoverClaudeCommands).mockResolvedValue(mockCommands);
+
+      const help = await getDynamicCommandsHelp();
+
+      expect(help).toBe(`*Claude Commands:*
+/empty-desc - No description available
+`);
+    });
+
+    it('should handle discovery errors gracefully', async () => {
+      const error = new Error('Discovery failed');
+      vi.mocked(discoverClaudeCommands).mockRejectedValue(error);
+
+      const help = await getDynamicCommandsHelp();
+
+      expect(help).toBe('');
+      expect(getLogger().error).toHaveBeenCalledWith(
+        { error },
+        'Failed to get dynamic commands help'
+      );
+    });
+
+    it('should handle commands with special characters in descriptions', async () => {
+      const mockCommands = [
+        {
+          name: 'special-chars',
+          filePath: '/test/commands/special-chars.md',
+          description: 'Command with *markdown* and _special_ chars!',
+          content: '# Special Chars',
+        },
+      ];
+
+      vi.mocked(discoverClaudeCommands).mockResolvedValue(mockCommands);
+
+      const help = await getDynamicCommandsHelp();
+
+      expect(help).toBe(`*Claude Commands:*
+/special-chars - Command with *markdown* and _special_ chars!
+`);
+    });
+
+    it('should handle very long command descriptions', async () => {
+      const longDescription = 'This is a very long command description that exceeds normal length expectations and might cause formatting issues in some interfaces but should be handled gracefully';
+
+      const mockCommands = [
+        {
+          name: 'long-desc',
+          filePath: '/test/commands/long-desc.md',
+          description: longDescription,
+          content: '# Long Description',
+        },
+      ];
+
+      vi.mocked(discoverClaudeCommands).mockResolvedValue(mockCommands);
+
+      const help = await getDynamicCommandsHelp();
+
+      expect(help).toBe(`*Claude Commands:*
+/long-desc - ${longDescription}
+`);
+    });
+  });
+
+  describe('Command Argument Parsing', () => {
+    it('should correctly parse simple arguments', async () => {
+      const mockCommands = [
+        {
+          name: 'test-cmd',
+          filePath: '/test/commands/test-cmd.md',
+          description: 'Test command',
+          content: '# Test',
+        },
+      ];
+
+      vi.mocked(discoverClaudeCommands).mockResolvedValue(mockCommands);
+      await registerDynamicCommands(mockBot);
+
+      const handlerCall = vi.mocked(mockBot.command).mock.calls[0];
+      const [, handler] = handlerCall;
+
+      const testCases = [
+        { text: '/test-cmd hello world', expectedArgs: 'hello world' },
+        { text: '/test-cmd single', expectedArgs: 'single' },
+        { text: '/test-cmd', expectedArgs: undefined },
+        { text: '/test-cmd   spaced   args   ', expectedArgs: 'spaced   args' },
+        { text: '/test-cmd "quoted argument"', expectedArgs: '"quoted argument"' },
+        { text: '/test-cmd --flag value', expectedArgs: '--flag value' },
+      ];
+
+      for (const testCase of testCases) {
+        vi.clearAllMocks();
+
+        const mockCtx = {
+          message: { text: testCase.text },
+        } as unknown as Context;
+
+        await handler(mockCtx);
+
+        expect(executeClaudeCommand).toHaveBeenCalledWith(
+          mockCtx,
+          'test-cmd',
+          testCase.expectedArgs
+        );
+      }
+    });
+
+    it('should handle commands with hyphens and underscores', async () => {
+      const mockCommands = [
+        {
+          name: 'multi-word-command',
+          filePath: '/test/commands/multi-word-command.md',
+          description: 'Multi word command',
+          content: '# Multi Word',
+        },
+        {
+          name: 'snake_case_command',
+          filePath: '/test/commands/snake_case_command.md',
+          description: 'Snake case command',
+          content: '# Snake Case',
+        },
+      ];
+
+      vi.mocked(discoverClaudeCommands).mockResolvedValue(mockCommands);
+      await registerDynamicCommands(mockBot);
+
+      expect(mockBot.command).toHaveBeenCalledWith('multi-word-command', expect.any(Function));
+      expect(mockBot.command).toHaveBeenCalledWith('snake_case_command', expect.any(Function));
+    });
+  });
+
+  describe('Error Handling and Edge Cases', () => {
+    it('should handle executeClaudeCommand failures gracefully', async () => {
+      const mockCommands = [
+        {
+          name: 'failing-command',
+          filePath: '/test/commands/failing-command.md',
+          description: 'A command that fails',
+          content: '# Failing Command',
+        },
+      ];
+
+      vi.mocked(discoverClaudeCommands).mockResolvedValue(mockCommands);
+      vi.mocked(executeClaudeCommand).mockRejectedValue(new Error('Execution failed'));
+
+      await registerDynamicCommands(mockBot);
+
+      const handlerCall = vi.mocked(mockBot.command).mock.calls[0];
+      const [, handler] = handlerCall;
+
+      const mockCtx = {
+        message: { text: '/failing-command test' },
+      } as unknown as Context;
+
+      // Should not throw error, should handle gracefully
+      await expect(handler(mockCtx)).rejects.toThrow('Execution failed');
+    });
+  });
+});

--- a/src/bot/__tests__/commands.dynamic.test.ts
+++ b/src/bot/__tests__/commands.dynamic.test.ts
@@ -15,7 +15,7 @@ vi.mock("../../logger.js");
 
 describe("Dynamic Commands - Registration and Help", () => {
   let mockBot: Bot;
-  let mockContext: Context;
+  let _mockContext: Context;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -26,7 +26,7 @@ describe("Dynamic Commands - Registration and Help", () => {
     } as unknown as Bot;
 
     // Mock context
-    mockContext = {
+    _mockContext = {
       message: {
         text: "/test-command arg1 arg2",
       },
@@ -147,7 +147,7 @@ describe("Dynamic Commands - Registration and Help", () => {
         },
       } as unknown as Context;
 
-      await handler(mockCtx);
+      await (handler as (ctx: Context) => Promise<void>)(mockCtx);
 
       expect(executeClaudeCommand).toHaveBeenCalledWith(
         mockCtx,
@@ -180,7 +180,7 @@ describe("Dynamic Commands - Registration and Help", () => {
         },
       } as unknown as Context;
 
-      await handler(mockCtx);
+      await (handler as (ctx: Context) => Promise<void>)(mockCtx);
 
       expect(executeClaudeCommand).toHaveBeenCalledWith(
         mockCtx,
@@ -213,7 +213,7 @@ describe("Dynamic Commands - Registration and Help", () => {
         },
       } as unknown as Context;
 
-      await handler(mockCtx);
+      await (handler as (ctx: Context) => Promise<void>)(mockCtx);
 
       expect(executeClaudeCommand).toHaveBeenCalledWith(
         mockCtx,
@@ -244,7 +244,7 @@ describe("Dynamic Commands - Registration and Help", () => {
         message: {},
       } as unknown as Context;
 
-      await handler(mockCtx);
+      await (handler as (ctx: Context) => Promise<void>)(mockCtx);
 
       expect(executeClaudeCommand).toHaveBeenCalledWith(
         mockCtx,
@@ -408,7 +408,7 @@ describe("Dynamic Commands - Registration and Help", () => {
           message: { text: testCase.text },
         } as unknown as Context;
 
-        await handler(mockCtx);
+        await (handler as (ctx: Context) => Promise<void>)(mockCtx);
 
         expect(executeClaudeCommand).toHaveBeenCalledWith(
           mockCtx,
@@ -474,7 +474,7 @@ describe("Dynamic Commands - Registration and Help", () => {
       } as unknown as Context;
 
       // Should not throw error, should handle gracefully
-      await expect(handler(mockCtx)).rejects.toThrow("Execution failed");
+      await expect((handler as (ctx: Context) => Promise<void>)(mockCtx)).rejects.toThrow("Execution failed");
     });
   });
 });

--- a/src/bot/__tests__/handlers.timestamp.test.ts
+++ b/src/bot/__tests__/handlers.timestamp.test.ts
@@ -27,15 +27,20 @@ describe("Message Handlers - Timestamp Extraction", () => {
 
     // Mock config
     vi.mocked(getConfig).mockReturnValue({
+      telegram: { botToken: "test-token" },
+      access: { allowedUserIds: [] },
       dataDir: "/test/data",
-    } as any);
+      rateLimit: { max: 100, windowMs: 60000 },
+      logging: { level: "info" },
+      claude: { command: "claude" },
+    });
 
     // Mock logger
     vi.mocked(getLogger).mockReturnValue({
       info: vi.fn(),
       debug: vi.fn(),
       error: vi.fn(),
-    } as any);
+    } as unknown as ReturnType<typeof getLogger>);
 
     // Mock user setup functions
     vi.mocked(ensureUserSetup).mockResolvedValue();

--- a/src/bot/__tests__/handlers.timestamp.test.ts
+++ b/src/bot/__tests__/handlers.timestamp.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Context } from 'grammy';
+import { textHandler } from '../handlers/text.js';
+import { executeClaudeQuery } from '../../claude/executor.js';
+import { getConfig } from '../../config.js';
+import { getLogger } from '../../logger.js';
+import {
+  ensureUserSetup,
+  getDownloadsPath,
+  getSessionId,
+  saveSessionId,
+} from '../../user/setup.js';
+import { sendChunkedResponse } from '../../telegram/chunker.js';
+import { sendDownloadFiles } from '../../telegram/fileSender.js';
+
+// Mock all dependencies
+vi.mock('../../claude/executor.js');
+vi.mock('../../config.js');
+vi.mock('../../logger.js');
+vi.mock('../../user/setup.js');
+vi.mock('../../telegram/chunker.js');
+vi.mock('../../telegram/fileSender.js');
+
+describe('Message Handlers - Timestamp Extraction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Mock config
+    vi.mocked(getConfig).mockReturnValue({
+      dataDir: '/test/data',
+    } as any);
+
+    // Mock logger
+    vi.mocked(getLogger).mockReturnValue({
+      info: vi.fn(),
+      debug: vi.fn(),
+      error: vi.fn(),
+    } as any);
+
+    // Mock user setup functions
+    vi.mocked(ensureUserSetup).mockResolvedValue();
+    vi.mocked(getDownloadsPath).mockReturnValue('/test/downloads');
+    vi.mocked(getSessionId).mockResolvedValue('test-session');
+    vi.mocked(saveSessionId).mockResolvedValue();
+
+    // Mock executor
+    vi.mocked(executeClaudeQuery).mockResolvedValue({
+      success: true,
+      output: 'Test response',
+      sessionId: 'test-session-new',
+    });
+
+    // Mock telegram functions
+    vi.mocked(sendChunkedResponse).mockResolvedValue();
+    vi.mocked(sendDownloadFiles).mockResolvedValue(0);
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('Text Handler - Timestamp Extraction', () => {
+    it('should extract timestamp from ctx.message.date and pass to executor', async () => {
+      const testTimestamp = 1709520000; // March 4, 2024
+
+      const mockContext = {
+        from: { id: 123, username: 'testuser', first_name: 'Test' },
+        message: {
+          text: 'Test message',
+          date: testTimestamp,
+        },
+        chat: { id: 456 },
+        reply: vi.fn().mockResolvedValue({ message_id: 789 }),
+        api: {
+          editMessageText: vi.fn().mockResolvedValue({}),
+          deleteMessage: vi.fn().mockResolvedValue({}),
+        },
+      } as unknown as Context;
+
+      await textHandler(mockContext);
+
+      // Verify executeClaudeQuery was called with the timestamp
+      expect(executeClaudeQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messageTimestamp: testTimestamp,
+        })
+      );
+    });
+
+    it('should handle undefined timestamp gracefully', async () => {
+      const mockContext = {
+        from: { id: 123, username: 'testuser', first_name: 'Test' },
+        message: {
+          text: 'Test message',
+          // date is undefined
+        },
+        chat: { id: 456 },
+        reply: vi.fn().mockResolvedValue({ message_id: 789 }),
+        api: {
+          editMessageText: vi.fn().mockResolvedValue({}),
+          deleteMessage: vi.fn().mockResolvedValue({}),
+        },
+      } as unknown as Context;
+
+      await textHandler(mockContext);
+
+      // Verify executeClaudeQuery was called with undefined timestamp
+      expect(executeClaudeQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messageTimestamp: undefined,
+        })
+      );
+    });
+
+    it('should handle zero timestamp', async () => {
+      const mockContext = {
+        from: { id: 123, username: 'testuser', first_name: 'Test' },
+        message: {
+          text: 'Test message',
+          date: 0, // Zero timestamp
+        },
+        chat: { id: 456 },
+        reply: vi.fn().mockResolvedValue({ message_id: 789 }),
+        api: {
+          editMessageText: vi.fn().mockResolvedValue({}),
+          deleteMessage: vi.fn().mockResolvedValue({}),
+        },
+      } as unknown as Context;
+
+      await textHandler(mockContext);
+
+      // Verify executeClaudeQuery was called with zero timestamp
+      expect(executeClaudeQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messageTimestamp: 0,
+        })
+      );
+    });
+
+    it('should pass all required parameters along with timestamp', async () => {
+      const testTimestamp = 1709520000;
+
+      const mockContext = {
+        from: { id: 123, username: 'testuser', first_name: 'Test' },
+        message: {
+          text: 'Test message for Claude',
+          date: testTimestamp,
+        },
+        chat: { id: 456 },
+        reply: vi.fn().mockResolvedValue({ message_id: 789 }),
+        api: {
+          editMessageText: vi.fn().mockResolvedValue({}),
+          deleteMessage: vi.fn().mockResolvedValue({}),
+        },
+      } as unknown as Context;
+
+      await textHandler(mockContext);
+
+      // Verify all parameters are passed correctly
+      expect(executeClaudeQuery).toHaveBeenCalledWith({
+        prompt: 'Test message for Claude',
+        userDir: expect.stringMatching(/\/test\/data\/123$/),
+        downloadsPath: '/test/downloads',
+        sessionId: 'test-session',
+        onProgress: expect.any(Function),
+        messageTimestamp: testTimestamp,
+      });
+    });
+
+    it('should not call executor when message text is missing', async () => {
+      const mockContext = {
+        from: { id: 123 },
+        message: {
+          date: 1709520000,
+          // text is undefined
+        },
+        chat: { id: 456 },
+      } as unknown as Context;
+
+      await textHandler(mockContext);
+
+      // Should not call executor when text is missing
+      expect(executeClaudeQuery).not.toHaveBeenCalled();
+    });
+
+    it('should not call executor when user ID is missing', async () => {
+      const mockContext = {
+        // from is undefined
+        message: {
+          text: 'Test message',
+          date: 1709520000,
+        },
+        chat: { id: 456 },
+      } as unknown as Context;
+
+      await textHandler(mockContext);
+
+      // Should not call executor when user ID is missing
+      expect(executeClaudeQuery).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Edge Cases and Error Scenarios', () => {
+    it('should handle negative timestamps correctly', async () => {
+      const negativeTimestamp = -86400; // One day before Unix epoch
+
+      const mockContext = {
+        from: { id: 123 },
+        message: {
+          text: 'Test message',
+          date: negativeTimestamp,
+        },
+        chat: { id: 456 },
+        reply: vi.fn().mockResolvedValue({ message_id: 789 }),
+        api: {
+          editMessageText: vi.fn().mockResolvedValue({}),
+          deleteMessage: vi.fn().mockResolvedValue({}),
+        },
+      } as unknown as Context;
+
+      await textHandler(mockContext);
+
+      expect(executeClaudeQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messageTimestamp: negativeTimestamp,
+        })
+      );
+    });
+
+    it('should handle very large timestamps', async () => {
+      const largeTimestamp = 4102444800; // Year 2099
+
+      const mockContext = {
+        from: { id: 123 },
+        message: {
+          text: 'Test message',
+          date: largeTimestamp,
+        },
+        chat: { id: 456 },
+        reply: vi.fn().mockResolvedValue({ message_id: 789 }),
+        api: {
+          editMessageText: vi.fn().mockResolvedValue({}),
+          deleteMessage: vi.fn().mockResolvedValue({}),
+        },
+      } as unknown as Context;
+
+      await textHandler(mockContext);
+
+      expect(executeClaudeQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messageTimestamp: largeTimestamp,
+        })
+      );
+    });
+
+    it('should continue normal execution flow even with timestamp extraction', async () => {
+      const testTimestamp = 1709520000;
+
+      const mockContext = {
+        from: { id: 123, username: 'testuser' },
+        message: {
+          text: 'Test message',
+          date: testTimestamp,
+        },
+        chat: { id: 456 },
+        reply: vi.fn().mockResolvedValue({ message_id: 789 }),
+        api: {
+          editMessageText: vi.fn().mockResolvedValue({}),
+          deleteMessage: vi.fn().mockResolvedValue({}),
+        },
+      } as unknown as Context;
+
+      await textHandler(mockContext);
+
+      // Verify full execution flow
+      expect(ensureUserSetup).toHaveBeenCalled();
+      expect(getSessionId).toHaveBeenCalled();
+      expect(executeClaudeQuery).toHaveBeenCalled();
+      expect(sendChunkedResponse).toHaveBeenCalledWith(mockContext, 'Test response');
+      expect(sendDownloadFiles).toHaveBeenCalled();
+      expect(saveSessionId).toHaveBeenCalledWith(
+        expect.any(String),
+        'test-session-new'
+      );
+    });
+  });
+
+  describe('Error Handling in Handler', () => {
+    it('should handle errors gracefully even when timestamp is present', async () => {
+      vi.mocked(executeClaudeQuery).mockRejectedValue(new Error('Test error'));
+
+      const mockContext = {
+        from: { id: 123 },
+        message: {
+          text: 'Test message',
+          date: 1709520000,
+        },
+        chat: { id: 456 },
+        reply: vi.fn().mockResolvedValue({ message_id: 789 }),
+        api: {
+          editMessageText: vi.fn().mockResolvedValue({}),
+          deleteMessage: vi.fn().mockResolvedValue({}),
+        },
+      } as unknown as Context;
+
+      await textHandler(mockContext);
+
+      // Should have tried to call executor with timestamp
+      expect(executeClaudeQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messageTimestamp: 1709520000,
+        })
+      );
+
+      // Should have sent error message to user
+      expect(mockContext.reply).toHaveBeenCalledWith(
+        'An error occurred: Test error'
+      );
+    });
+  });
+});

--- a/src/bot/__tests__/handlers.timestamp.test.ts
+++ b/src/bot/__tests__/handlers.timestamp.test.ts
@@ -1,33 +1,33 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { Context } from 'grammy';
-import { textHandler } from '../handlers/text.js';
-import { executeClaudeQuery } from '../../claude/executor.js';
-import { getConfig } from '../../config.js';
-import { getLogger } from '../../logger.js';
+import type { Context } from "grammy";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { executeClaudeQuery } from "../../claude/executor.js";
+import { getConfig } from "../../config.js";
+import { getLogger } from "../../logger.js";
+import { sendChunkedResponse } from "../../telegram/chunker.js";
+import { sendDownloadFiles } from "../../telegram/fileSender.js";
 import {
   ensureUserSetup,
   getDownloadsPath,
   getSessionId,
   saveSessionId,
-} from '../../user/setup.js';
-import { sendChunkedResponse } from '../../telegram/chunker.js';
-import { sendDownloadFiles } from '../../telegram/fileSender.js';
+} from "../../user/setup.js";
+import { textHandler } from "../handlers/text.js";
 
 // Mock all dependencies
-vi.mock('../../claude/executor.js');
-vi.mock('../../config.js');
-vi.mock('../../logger.js');
-vi.mock('../../user/setup.js');
-vi.mock('../../telegram/chunker.js');
-vi.mock('../../telegram/fileSender.js');
+vi.mock("../../claude/executor.js");
+vi.mock("../../config.js");
+vi.mock("../../logger.js");
+vi.mock("../../user/setup.js");
+vi.mock("../../telegram/chunker.js");
+vi.mock("../../telegram/fileSender.js");
 
-describe('Message Handlers - Timestamp Extraction', () => {
+describe("Message Handlers - Timestamp Extraction", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
     // Mock config
     vi.mocked(getConfig).mockReturnValue({
-      dataDir: '/test/data',
+      dataDir: "/test/data",
     } as any);
 
     // Mock logger
@@ -39,15 +39,15 @@ describe('Message Handlers - Timestamp Extraction', () => {
 
     // Mock user setup functions
     vi.mocked(ensureUserSetup).mockResolvedValue();
-    vi.mocked(getDownloadsPath).mockReturnValue('/test/downloads');
-    vi.mocked(getSessionId).mockResolvedValue('test-session');
+    vi.mocked(getDownloadsPath).mockReturnValue("/test/downloads");
+    vi.mocked(getSessionId).mockResolvedValue("test-session");
     vi.mocked(saveSessionId).mockResolvedValue();
 
     // Mock executor
     vi.mocked(executeClaudeQuery).mockResolvedValue({
       success: true,
-      output: 'Test response',
-      sessionId: 'test-session-new',
+      output: "Test response",
+      sessionId: "test-session-new",
     });
 
     // Mock telegram functions
@@ -59,14 +59,14 @@ describe('Message Handlers - Timestamp Extraction', () => {
     vi.resetAllMocks();
   });
 
-  describe('Text Handler - Timestamp Extraction', () => {
-    it('should extract timestamp from ctx.message.date and pass to executor', async () => {
+  describe("Text Handler - Timestamp Extraction", () => {
+    it("should extract timestamp from ctx.message.date and pass to executor", async () => {
       const testTimestamp = 1709520000; // March 4, 2024
 
       const mockContext = {
-        from: { id: 123, username: 'testuser', first_name: 'Test' },
+        from: { id: 123, username: "testuser", first_name: "Test" },
         message: {
-          text: 'Test message',
+          text: "Test message",
           date: testTimestamp,
         },
         chat: { id: 456 },
@@ -83,15 +83,15 @@ describe('Message Handlers - Timestamp Extraction', () => {
       expect(executeClaudeQuery).toHaveBeenCalledWith(
         expect.objectContaining({
           messageTimestamp: testTimestamp,
-        })
+        }),
       );
     });
 
-    it('should handle undefined timestamp gracefully', async () => {
+    it("should handle undefined timestamp gracefully", async () => {
       const mockContext = {
-        from: { id: 123, username: 'testuser', first_name: 'Test' },
+        from: { id: 123, username: "testuser", first_name: "Test" },
         message: {
-          text: 'Test message',
+          text: "Test message",
           // date is undefined
         },
         chat: { id: 456 },
@@ -108,15 +108,15 @@ describe('Message Handlers - Timestamp Extraction', () => {
       expect(executeClaudeQuery).toHaveBeenCalledWith(
         expect.objectContaining({
           messageTimestamp: undefined,
-        })
+        }),
       );
     });
 
-    it('should handle zero timestamp', async () => {
+    it("should handle zero timestamp", async () => {
       const mockContext = {
-        from: { id: 123, username: 'testuser', first_name: 'Test' },
+        from: { id: 123, username: "testuser", first_name: "Test" },
         message: {
-          text: 'Test message',
+          text: "Test message",
           date: 0, // Zero timestamp
         },
         chat: { id: 456 },
@@ -133,17 +133,17 @@ describe('Message Handlers - Timestamp Extraction', () => {
       expect(executeClaudeQuery).toHaveBeenCalledWith(
         expect.objectContaining({
           messageTimestamp: 0,
-        })
+        }),
       );
     });
 
-    it('should pass all required parameters along with timestamp', async () => {
+    it("should pass all required parameters along with timestamp", async () => {
       const testTimestamp = 1709520000;
 
       const mockContext = {
-        from: { id: 123, username: 'testuser', first_name: 'Test' },
+        from: { id: 123, username: "testuser", first_name: "Test" },
         message: {
-          text: 'Test message for Claude',
+          text: "Test message for Claude",
           date: testTimestamp,
         },
         chat: { id: 456 },
@@ -158,16 +158,16 @@ describe('Message Handlers - Timestamp Extraction', () => {
 
       // Verify all parameters are passed correctly
       expect(executeClaudeQuery).toHaveBeenCalledWith({
-        prompt: 'Test message for Claude',
+        prompt: "Test message for Claude",
         userDir: expect.stringMatching(/\/test\/data\/123$/),
-        downloadsPath: '/test/downloads',
-        sessionId: 'test-session',
+        downloadsPath: "/test/downloads",
+        sessionId: "test-session",
         onProgress: expect.any(Function),
         messageTimestamp: testTimestamp,
       });
     });
 
-    it('should not call executor when message text is missing', async () => {
+    it("should not call executor when message text is missing", async () => {
       const mockContext = {
         from: { id: 123 },
         message: {
@@ -183,11 +183,11 @@ describe('Message Handlers - Timestamp Extraction', () => {
       expect(executeClaudeQuery).not.toHaveBeenCalled();
     });
 
-    it('should not call executor when user ID is missing', async () => {
+    it("should not call executor when user ID is missing", async () => {
       const mockContext = {
         // from is undefined
         message: {
-          text: 'Test message',
+          text: "Test message",
           date: 1709520000,
         },
         chat: { id: 456 },
@@ -200,14 +200,14 @@ describe('Message Handlers - Timestamp Extraction', () => {
     });
   });
 
-  describe('Edge Cases and Error Scenarios', () => {
-    it('should handle negative timestamps correctly', async () => {
+  describe("Edge Cases and Error Scenarios", () => {
+    it("should handle negative timestamps correctly", async () => {
       const negativeTimestamp = -86400; // One day before Unix epoch
 
       const mockContext = {
         from: { id: 123 },
         message: {
-          text: 'Test message',
+          text: "Test message",
           date: negativeTimestamp,
         },
         chat: { id: 456 },
@@ -223,17 +223,17 @@ describe('Message Handlers - Timestamp Extraction', () => {
       expect(executeClaudeQuery).toHaveBeenCalledWith(
         expect.objectContaining({
           messageTimestamp: negativeTimestamp,
-        })
+        }),
       );
     });
 
-    it('should handle very large timestamps', async () => {
+    it("should handle very large timestamps", async () => {
       const largeTimestamp = 4102444800; // Year 2099
 
       const mockContext = {
         from: { id: 123 },
         message: {
-          text: 'Test message',
+          text: "Test message",
           date: largeTimestamp,
         },
         chat: { id: 456 },
@@ -249,17 +249,17 @@ describe('Message Handlers - Timestamp Extraction', () => {
       expect(executeClaudeQuery).toHaveBeenCalledWith(
         expect.objectContaining({
           messageTimestamp: largeTimestamp,
-        })
+        }),
       );
     });
 
-    it('should continue normal execution flow even with timestamp extraction', async () => {
+    it("should continue normal execution flow even with timestamp extraction", async () => {
       const testTimestamp = 1709520000;
 
       const mockContext = {
-        from: { id: 123, username: 'testuser' },
+        from: { id: 123, username: "testuser" },
         message: {
-          text: 'Test message',
+          text: "Test message",
           date: testTimestamp,
         },
         chat: { id: 456 },
@@ -276,23 +276,26 @@ describe('Message Handlers - Timestamp Extraction', () => {
       expect(ensureUserSetup).toHaveBeenCalled();
       expect(getSessionId).toHaveBeenCalled();
       expect(executeClaudeQuery).toHaveBeenCalled();
-      expect(sendChunkedResponse).toHaveBeenCalledWith(mockContext, 'Test response');
+      expect(sendChunkedResponse).toHaveBeenCalledWith(
+        mockContext,
+        "Test response",
+      );
       expect(sendDownloadFiles).toHaveBeenCalled();
       expect(saveSessionId).toHaveBeenCalledWith(
         expect.any(String),
-        'test-session-new'
+        "test-session-new",
       );
     });
   });
 
-  describe('Error Handling in Handler', () => {
-    it('should handle errors gracefully even when timestamp is present', async () => {
-      vi.mocked(executeClaudeQuery).mockRejectedValue(new Error('Test error'));
+  describe("Error Handling in Handler", () => {
+    it("should handle errors gracefully even when timestamp is present", async () => {
+      vi.mocked(executeClaudeQuery).mockRejectedValue(new Error("Test error"));
 
       const mockContext = {
         from: { id: 123 },
         message: {
-          text: 'Test message',
+          text: "Test message",
           date: 1709520000,
         },
         chat: { id: 456 },
@@ -309,12 +312,12 @@ describe('Message Handlers - Timestamp Extraction', () => {
       expect(executeClaudeQuery).toHaveBeenCalledWith(
         expect.objectContaining({
           messageTimestamp: 1709520000,
-        })
+        }),
       );
 
       // Should have sent error message to user
       expect(mockContext.reply).toHaveBeenCalledWith(
-        'An error occurred: Test error'
+        "An error occurred: Test error",
       );
     });
   });

--- a/src/bot/commands/dynamic.improved.ts
+++ b/src/bot/commands/dynamic.improved.ts
@@ -145,7 +145,7 @@ export async function getDynamicCommandsHelp(): Promise<string> {
       // Truncate very long descriptions for better formatting
       const truncatedDescription =
         description.length > 80
-          ? description.slice(0, 77) + "..."
+          ? `${description.slice(0, 77)}...`
           : description;
 
       help += `/${command.name} - ${truncatedDescription}\n`;

--- a/src/bot/commands/dynamic.improved.ts
+++ b/src/bot/commands/dynamic.improved.ts
@@ -1,0 +1,222 @@
+import type { Bot, Context } from "grammy";
+import { executeClaudeCommand } from "../../claude/commandExecutor.js";
+import {
+  getValidClaudeCommands,
+  getCommandValidationErrors,
+  clearCommandsCache,
+} from "../../claude/commands.improved.js";
+import { getLogger } from "../../logger.js";
+
+// Cache registered command names to avoid duplicate registrations
+let registeredCommands: Set<string> = new Set();
+
+/**
+ * Register all valid discovered Claude commands with the Telegram bot
+ */
+export async function registerDynamicCommands(bot: Bot): Promise<void> {
+  const logger = getLogger();
+
+  try {
+    // Get only valid commands (filtering out conflicts and invalid names)
+    const commands = await getValidClaudeCommands();
+    const validationErrors = await getCommandValidationErrors();
+
+    if (validationErrors.length > 0) {
+      logger.warn({
+        errors: validationErrors,
+        count: validationErrors.length,
+      }, 'Found invalid Claude commands that will be skipped');
+    }
+
+    if (commands.length === 0) {
+      logger.debug('No valid Claude commands found to register');
+      return;
+    }
+
+    let registeredCount = 0;
+    let skippedCount = 0;
+
+    // Register each valid command
+    for (const command of commands) {
+      try {
+        // Skip if already registered
+        if (registeredCommands.has(command.name)) {
+          logger.debug({ commandName: command.name }, 'Command already registered, skipping');
+          skippedCount++;
+          continue;
+        }
+
+        // Create command handler with improved error handling
+        const handler = async (ctx: Context): Promise<void> => {
+          try {
+            // Extract arguments from the command message
+            const messageText = ctx.message?.text || "";
+            const commandPattern = new RegExp(`^/${command.name}\\s*(.*)$`);
+            const match = messageText.match(commandPattern);
+            const args = match?.[1]?.trim() || undefined;
+
+            // Execute the command with error handling
+            await executeClaudeCommand(ctx, command.name, args);
+          } catch (error) {
+            logger.error(
+              {
+                error,
+                commandName: command.name,
+                userId: ctx.from?.id,
+              },
+              'Error in dynamic command handler'
+            );
+
+            // Send user-friendly error message
+            try {
+              await ctx.reply(
+                `❌ An error occurred while executing /${command.name}. Please try again later.`,
+                { parse_mode: 'Markdown' }
+              );
+            } catch (replyError) {
+              // If even the error reply fails, just log it
+              logger.error({ error: replyError }, 'Failed to send error reply');
+            }
+          }
+        };
+
+        // Register the command with the bot
+        bot.command(command.name, handler);
+        registeredCommands.add(command.name);
+        registeredCount++;
+
+        logger.debug(
+          {
+            commandName: command.name,
+            description: command.description,
+            filePath: command.filePath,
+          },
+          'Registered dynamic Claude command'
+        );
+      } catch (error) {
+        logger.error(
+          { error, commandName: command.name },
+          'Failed to register individual command'
+        );
+        skippedCount++;
+      }
+    }
+
+    logger.info(
+      {
+        registered: registeredCount,
+        skipped: skippedCount,
+        invalid: validationErrors.length,
+        total: commands.length + validationErrors.length,
+      },
+      'Dynamic Claude command registration complete'
+    );
+  } catch (error) {
+    logger.error({ error }, 'Failed to register dynamic commands');
+  }
+}
+
+/**
+ * Get formatted help text for all valid discovered Claude commands
+ */
+export async function getDynamicCommandsHelp(): Promise<string> {
+  try {
+    const commands = await getValidClaudeCommands();
+
+    if (commands.length === 0) {
+      return "";
+    }
+
+    let help = "*Claude Commands:*\n";
+
+    // Sort commands alphabetically for better UX
+    const sortedCommands = commands.sort((a, b) => a.name.localeCompare(b.name));
+
+    for (const command of sortedCommands) {
+      const description = command.description || "No description available";
+      // Truncate very long descriptions for better formatting
+      const truncatedDescription = description.length > 80
+        ? description.slice(0, 77) + "..."
+        : description;
+
+      help += `/${command.name} - ${truncatedDescription}\n`;
+    }
+
+    // Add information about invalid commands if any exist
+    const validationErrors = await getCommandValidationErrors();
+    if (validationErrors.length > 0) {
+      help += `\n_Note: ${validationErrors.length} command(s) skipped due to validation errors._`;
+    }
+
+    return help;
+  } catch (error) {
+    const logger = getLogger();
+    logger.error({ error }, "Failed to get dynamic commands help");
+    return "";
+  }
+}
+
+/**
+ * Refresh command registration (useful when commands are added/removed)
+ */
+export async function refreshDynamicCommands(bot: Bot): Promise<void> {
+  const logger = getLogger();
+
+  try {
+    // Clear caches
+    clearCommandsCache();
+    registeredCommands.clear();
+
+    logger.info('Cleared command caches, re-registering commands');
+
+    // Re-register commands
+    await registerDynamicCommands(bot);
+  } catch (error) {
+    logger.error({ error }, 'Failed to refresh dynamic commands');
+  }
+}
+
+/**
+ * Get registration statistics for monitoring
+ */
+export async function getDynamicCommandStats(): Promise<{
+  registered: number;
+  invalid: number;
+  errors: Array<{ name: string; error: string }>;
+}> {
+  try {
+    const validCommands = await getValidClaudeCommands();
+    const errors = await getCommandValidationErrors();
+
+    return {
+      registered: validCommands.length,
+      invalid: errors.length,
+      errors,
+    };
+  } catch (error) {
+    const logger = getLogger();
+    logger.error({ error }, 'Failed to get command stats');
+
+    return {
+      registered: 0,
+      invalid: 0,
+      errors: [],
+    };
+  }
+}
+
+/**
+ * Check if a command name would conflict with built-in commands
+ */
+export function wouldConflictWithBuiltIn(commandName: string): boolean {
+  // Use the same built-in list from the commands module
+  const builtIns = ['start', 'help', 'clear', 'stop', 'restart', 'settings', 'version', 'status', 'ping', 'cancel'];
+  return builtIns.includes(commandName.toLowerCase());
+}
+
+/**
+ * Get list of currently registered dynamic command names
+ */
+export function getRegisteredCommandNames(): string[] {
+  return Array.from(registeredCommands).sort();
+}

--- a/src/bot/commands/dynamic.improved.ts
+++ b/src/bot/commands/dynamic.improved.ts
@@ -1,14 +1,14 @@
 import type { Bot, Context } from "grammy";
 import { executeClaudeCommand } from "../../claude/commandExecutor.js";
 import {
-  getValidClaudeCommands,
-  getCommandValidationErrors,
   clearCommandsCache,
+  getCommandValidationErrors,
+  getValidClaudeCommands,
 } from "../../claude/commands.improved.js";
 import { getLogger } from "../../logger.js";
 
 // Cache registered command names to avoid duplicate registrations
-let registeredCommands: Set<string> = new Set();
+const registeredCommands: Set<string> = new Set();
 
 /**
  * Register all valid discovered Claude commands with the Telegram bot
@@ -22,14 +22,17 @@ export async function registerDynamicCommands(bot: Bot): Promise<void> {
     const validationErrors = await getCommandValidationErrors();
 
     if (validationErrors.length > 0) {
-      logger.warn({
-        errors: validationErrors,
-        count: validationErrors.length,
-      }, 'Found invalid Claude commands that will be skipped');
+      logger.warn(
+        {
+          errors: validationErrors,
+          count: validationErrors.length,
+        },
+        "Found invalid Claude commands that will be skipped",
+      );
     }
 
     if (commands.length === 0) {
-      logger.debug('No valid Claude commands found to register');
+      logger.debug("No valid Claude commands found to register");
       return;
     }
 
@@ -41,7 +44,10 @@ export async function registerDynamicCommands(bot: Bot): Promise<void> {
       try {
         // Skip if already registered
         if (registeredCommands.has(command.name)) {
-          logger.debug({ commandName: command.name }, 'Command already registered, skipping');
+          logger.debug(
+            { commandName: command.name },
+            "Command already registered, skipping",
+          );
           skippedCount++;
           continue;
         }
@@ -64,18 +70,18 @@ export async function registerDynamicCommands(bot: Bot): Promise<void> {
                 commandName: command.name,
                 userId: ctx.from?.id,
               },
-              'Error in dynamic command handler'
+              "Error in dynamic command handler",
             );
 
             // Send user-friendly error message
             try {
               await ctx.reply(
                 `❌ An error occurred while executing /${command.name}. Please try again later.`,
-                { parse_mode: 'Markdown' }
+                { parse_mode: "Markdown" },
               );
             } catch (replyError) {
               // If even the error reply fails, just log it
-              logger.error({ error: replyError }, 'Failed to send error reply');
+              logger.error({ error: replyError }, "Failed to send error reply");
             }
           }
         };
@@ -91,12 +97,12 @@ export async function registerDynamicCommands(bot: Bot): Promise<void> {
             description: command.description,
             filePath: command.filePath,
           },
-          'Registered dynamic Claude command'
+          "Registered dynamic Claude command",
         );
       } catch (error) {
         logger.error(
           { error, commandName: command.name },
-          'Failed to register individual command'
+          "Failed to register individual command",
         );
         skippedCount++;
       }
@@ -109,10 +115,10 @@ export async function registerDynamicCommands(bot: Bot): Promise<void> {
         invalid: validationErrors.length,
         total: commands.length + validationErrors.length,
       },
-      'Dynamic Claude command registration complete'
+      "Dynamic Claude command registration complete",
     );
   } catch (error) {
-    logger.error({ error }, 'Failed to register dynamic commands');
+    logger.error({ error }, "Failed to register dynamic commands");
   }
 }
 
@@ -130,14 +136,17 @@ export async function getDynamicCommandsHelp(): Promise<string> {
     let help = "*Claude Commands:*\n";
 
     // Sort commands alphabetically for better UX
-    const sortedCommands = commands.sort((a, b) => a.name.localeCompare(b.name));
+    const sortedCommands = commands.sort((a, b) =>
+      a.name.localeCompare(b.name),
+    );
 
     for (const command of sortedCommands) {
       const description = command.description || "No description available";
       // Truncate very long descriptions for better formatting
-      const truncatedDescription = description.length > 80
-        ? description.slice(0, 77) + "..."
-        : description;
+      const truncatedDescription =
+        description.length > 80
+          ? description.slice(0, 77) + "..."
+          : description;
 
       help += `/${command.name} - ${truncatedDescription}\n`;
     }
@@ -167,12 +176,12 @@ export async function refreshDynamicCommands(bot: Bot): Promise<void> {
     clearCommandsCache();
     registeredCommands.clear();
 
-    logger.info('Cleared command caches, re-registering commands');
+    logger.info("Cleared command caches, re-registering commands");
 
     // Re-register commands
     await registerDynamicCommands(bot);
   } catch (error) {
-    logger.error({ error }, 'Failed to refresh dynamic commands');
+    logger.error({ error }, "Failed to refresh dynamic commands");
   }
 }
 
@@ -195,7 +204,7 @@ export async function getDynamicCommandStats(): Promise<{
     };
   } catch (error) {
     const logger = getLogger();
-    logger.error({ error }, 'Failed to get command stats');
+    logger.error({ error }, "Failed to get command stats");
 
     return {
       registered: 0,
@@ -210,7 +219,18 @@ export async function getDynamicCommandStats(): Promise<{
  */
 export function wouldConflictWithBuiltIn(commandName: string): boolean {
   // Use the same built-in list from the commands module
-  const builtIns = ['start', 'help', 'clear', 'stop', 'restart', 'settings', 'version', 'status', 'ping', 'cancel'];
+  const builtIns = [
+    "start",
+    "help",
+    "clear",
+    "stop",
+    "restart",
+    "settings",
+    "version",
+    "status",
+    "ping",
+    "cancel",
+  ];
   return builtIns.includes(commandName.toLowerCase());
 }
 

--- a/src/bot/commands/dynamic.ts
+++ b/src/bot/commands/dynamic.ts
@@ -1,0 +1,77 @@
+import type { Bot, Context } from "grammy";
+import { executeClaudeCommand } from "../../claude/commandExecutor.js";
+import { discoverClaudeCommands } from "../../claude/commands.js";
+import { getLogger } from "../../logger.js";
+
+/**
+ * Register all discovered Claude commands with the Telegram bot
+ */
+export async function registerDynamicCommands(bot: Bot): Promise<void> {
+  const logger = getLogger();
+
+  try {
+    const commands = await discoverClaudeCommands();
+
+    if (commands.length === 0) {
+      logger.debug("No Claude commands found to register");
+      return;
+    }
+
+    // Register each discovered command
+    for (const command of commands) {
+      const handler = async (ctx: Context): Promise<void> => {
+        // Extract arguments from the command message
+        // For /command arg1 arg2, we get the text after the command
+        const messageText = ctx.message?.text || "";
+        const commandPattern = new RegExp(`^/${command.name}\\s*(.*)$`);
+        const match = messageText.match(commandPattern);
+        const args = match?.[1]?.trim() || undefined;
+
+        await executeClaudeCommand(ctx, command.name, args);
+      };
+
+      // Register the command with the bot
+      bot.command(command.name, handler);
+
+      logger.debug(
+        {
+          commandName: command.name,
+          description: command.description,
+        },
+        "Registered dynamic Claude command",
+      );
+    }
+
+    logger.info(
+      { count: commands.length },
+      "Registered dynamic Claude commands",
+    );
+  } catch (error) {
+    logger.error({ error }, "Failed to register dynamic commands");
+  }
+}
+
+/**
+ * Get formatted help text for all discovered Claude commands
+ */
+export async function getDynamicCommandsHelp(): Promise<string> {
+  try {
+    const commands = await discoverClaudeCommands();
+
+    if (commands.length === 0) {
+      return "";
+    }
+
+    let help = "*Claude Commands:*\n";
+    for (const command of commands) {
+      const description = command.description || "No description available";
+      help += `/${command.name} - ${description}\n`;
+    }
+
+    return help;
+  } catch (error) {
+    const logger = getLogger();
+    logger.error({ error }, "Failed to get dynamic commands help");
+    return "";
+  }
+}

--- a/src/bot/commands/help.ts
+++ b/src/bot/commands/help.ts
@@ -1,20 +1,24 @@
 import type { Context } from "grammy";
+import { getDynamicCommandsHelp } from "./dynamic.js";
 
 export async function helpHandler(ctx: Context): Promise<void> {
-  await ctx.reply(
+  const dynamicHelp = await getDynamicCommandsHelp();
+
+  const helpText =
     `*Claude Code Telegram Bot*\n\n` +
-      `*Commands:*\n` +
-      `/start - Welcome message\n` +
-      `/help - Show this help\n` +
-      `/clear - Clear conversation history\n\n` +
-      `*Usage:*\n` +
-      `Just send any message to chat with Claude.\n` +
-      `You can also send images and documents for analysis.\n\n` +
-      `Your conversation history is preserved between messages. ` +
-      `Use /clear to start a fresh conversation.\n\n` +
-      `*Configuration:*\n` +
-      `Claude reads configuration from your .claude folder.\n` +
-      `Edit CLAUDE.md for system prompts and .claude/settings.json for permissions.`,
-    { parse_mode: "Markdown" },
-  );
+    `*Built-in Commands:*\n` +
+    `/start - Welcome message\n` +
+    `/help - Show this help\n` +
+    `/clear - Clear conversation history\n\n` +
+    (dynamicHelp ? `${dynamicHelp}\n` : "") +
+    `*Usage:*\n` +
+    `Just send any message to chat with Claude.\n` +
+    `You can also send images and documents for analysis.\n\n` +
+    `Your conversation history is preserved between messages. ` +
+    `Use /clear to start a fresh conversation.\n\n` +
+    `*Configuration:*\n` +
+    `Claude reads configuration from your .claude folder.\n` +
+    `Edit CLAUDE.md for system prompts and .claude/settings.json for permissions.`;
+
+  await ctx.reply(helpText, { parse_mode: "Markdown" });
 }

--- a/src/bot/handlers/document.ts
+++ b/src/bot/handlers/document.ts
@@ -59,6 +59,7 @@ export async function documentHandler(ctx: Context): Promise<void> {
   const userId = ctx.from?.id;
   const document = ctx.message?.document;
   const caption = ctx.message?.caption || "Please analyze this document.";
+  const messageTimestamp = ctx.message?.date;
 
   if (!userId || !document) {
     return;
@@ -143,6 +144,7 @@ export async function documentHandler(ctx: Context): Promise<void> {
       downloadsPath,
       sessionId,
       onProgress,
+      messageTimestamp,
     });
 
     try {

--- a/src/bot/handlers/photo.ts
+++ b/src/bot/handlers/photo.ts
@@ -24,6 +24,7 @@ export async function photoHandler(ctx: Context): Promise<void> {
   const userId = ctx.from?.id;
   const photo = ctx.message?.photo;
   const caption = ctx.message?.caption || "Please analyze this image.";
+  const messageTimestamp = ctx.message?.date;
 
   if (!userId || !photo || photo.length === 0) {
     return;
@@ -94,6 +95,7 @@ export async function photoHandler(ctx: Context): Promise<void> {
       downloadsPath,
       sessionId,
       onProgress,
+      messageTimestamp,
     });
 
     try {

--- a/src/bot/handlers/text.ts
+++ b/src/bot/handlers/text.ts
@@ -20,6 +20,7 @@ export async function textHandler(ctx: Context): Promise<void> {
   const logger = getLogger();
   const userId = ctx.from?.id;
   const messageText = ctx.message?.text;
+  const messageTimestamp = ctx.message?.date;
 
   if (!userId || !messageText) {
     return;
@@ -83,6 +84,7 @@ export async function textHandler(ctx: Context): Promise<void> {
       downloadsPath,
       sessionId,
       onProgress,
+      messageTimestamp,
     });
     logger.debug(
       { success: result.success, error: result.error },

--- a/src/bot/handlers/voice.ts
+++ b/src/bot/handlers/voice.ts
@@ -49,6 +49,7 @@ export async function voiceHandler(ctx: Context): Promise<void> {
   const logger = getLogger();
   const userId = ctx.from?.id;
   const voice = ctx.message?.voice;
+  const messageTimestamp = ctx.message?.date;
 
   if (!userId || !voice) {
     return;
@@ -173,6 +174,7 @@ export async function voiceHandler(ctx: Context): Promise<void> {
       downloadsPath,
       sessionId,
       onProgress,
+      messageTimestamp,
     });
 
     // Delete status message

--- a/src/claude/__tests__/commandExecutor.test.ts
+++ b/src/claude/__tests__/commandExecutor.test.ts
@@ -1,0 +1,560 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Context } from 'grammy';
+import { executeClaudeCommand } from '../commandExecutor.js';
+import { getClaudeCommand } from '../commands.js';
+import { executeClaudeQuery } from '../executor.js';
+import { getConfig } from '../../config.js';
+import { getLogger } from '../../logger.js';
+import {
+  ensureUserSetup,
+  getDownloadsPath,
+  getSessionId,
+  saveSessionId,
+} from '../../user/setup.js';
+import { sendChunkedResponse } from '../../telegram/chunker.js';
+import { sendDownloadFiles } from '../../telegram/fileSender.js';
+
+// Mock dependencies
+vi.mock('../commands.js');
+vi.mock('../executor.js');
+vi.mock('../../config.js');
+vi.mock('../../logger.js');
+vi.mock('../../user/setup.js');
+vi.mock('../../telegram/chunker.js');
+vi.mock('../../telegram/fileSender.js');
+
+describe('Command Executor - Integration Tests', () => {
+  let mockContext: Context;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Mock context
+    mockContext = {
+      from: { id: 123 },
+      chat: { id: 456 },
+      reply: vi.fn().mockResolvedValue({ message_id: 789 }),
+      api: {
+        editMessageText: vi.fn().mockResolvedValue({}),
+        deleteMessage: vi.fn().mockResolvedValue({}),
+      },
+    } as unknown as Context;
+
+    // Mock config
+    vi.mocked(getConfig).mockReturnValue({
+      dataDir: '/test/data',
+    } as any);
+
+    // Mock logger
+    vi.mocked(getLogger).mockReturnValue({
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as any);
+
+    // Mock user setup functions
+    vi.mocked(ensureUserSetup).mockResolvedValue();
+    vi.mocked(getDownloadsPath).mockReturnValue('/test/downloads');
+    vi.mocked(getSessionId).mockResolvedValue('test-session');
+    vi.mocked(saveSessionId).mockResolvedValue();
+
+    // Mock telegram functions
+    vi.mocked(sendChunkedResponse).mockResolvedValue();
+    vi.mocked(sendDownloadFiles).mockResolvedValue(0);
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('Successful Command Execution', () => {
+    it('should execute Claude command successfully', async () => {
+      const mockCommand = {
+        name: 'test-command',
+        filePath: '/test/commands/test-command.md',
+        description: 'A test command',
+        content: '# Test Command',
+      };
+
+      vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
+      vi.mocked(executeClaudeQuery).mockResolvedValue({
+        success: true,
+        output: 'Command executed successfully',
+        sessionId: 'new-session-123',
+      });
+
+      await executeClaudeCommand(mockContext, 'test-command', 'arg1 arg2');
+
+      // Verify command lookup
+      expect(getClaudeCommand).toHaveBeenCalledWith('test-command');
+
+      // Verify user setup
+      expect(ensureUserSetup).toHaveBeenCalledWith('/test/data/123');
+
+      // Verify Claude execution with correct prompt
+      expect(executeClaudeQuery).toHaveBeenCalledWith({
+        prompt: '/test-command arg1 arg2',
+        userDir: '/test/data/123',
+        downloadsPath: '/test/downloads',
+        sessionId: 'test-session',
+        onProgress: expect.any(Function),
+      });
+
+      // Verify response
+      expect(sendChunkedResponse).toHaveBeenCalledWith(
+        mockContext,
+        'Command executed successfully'
+      );
+
+      // Verify session save
+      expect(saveSessionId).toHaveBeenCalledWith('/test/data/123', 'new-session-123');
+
+      // Verify files sent
+      expect(sendDownloadFiles).toHaveBeenCalledWith(mockContext, '/test/data/123');
+    });
+
+    it('should handle command without arguments', async () => {
+      const mockCommand = {
+        name: 'simple-command',
+        filePath: '/test/commands/simple-command.md',
+        description: 'A simple command',
+        content: '# Simple Command',
+      };
+
+      vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
+      vi.mocked(executeClaudeQuery).mockResolvedValue({
+        success: true,
+        output: 'Simple command result',
+      });
+
+      await executeClaudeCommand(mockContext, 'simple-command');
+
+      expect(executeClaudeQuery).toHaveBeenCalledWith({
+        prompt: '/simple-command',
+        userDir: '/test/data/123',
+        downloadsPath: '/test/downloads',
+        sessionId: 'test-session',
+        onProgress: expect.any(Function),
+      });
+    });
+
+    it('should handle command with empty arguments', async () => {
+      const mockCommand = {
+        name: 'test-command',
+        filePath: '/test/commands/test-command.md',
+        description: 'A test command',
+        content: '# Test Command',
+      };
+
+      vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
+      vi.mocked(executeClaudeQuery).mockResolvedValue({
+        success: true,
+        output: 'Command result',
+      });
+
+      await executeClaudeCommand(mockContext, 'test-command', '   \t  \n  ');
+
+      expect(executeClaudeQuery).toHaveBeenCalledWith({
+        prompt: '/test-command',
+        userDir: '/test/data/123',
+        downloadsPath: '/test/downloads',
+        sessionId: 'test-session',
+        onProgress: expect.any(Function),
+      });
+    });
+
+    it('should handle file downloads', async () => {
+      const mockCommand = {
+        name: 'file-command',
+        filePath: '/test/commands/file-command.md',
+        description: 'A command that creates files',
+        content: '# File Command',
+      };
+
+      vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
+      vi.mocked(executeClaudeQuery).mockResolvedValue({
+        success: true,
+        output: 'Files created',
+        sessionId: 'session-with-files',
+      });
+      vi.mocked(sendDownloadFiles).mockResolvedValue(3);
+
+      await executeClaudeCommand(mockContext, 'file-command', 'create files');
+
+      expect(sendDownloadFiles).toHaveBeenCalledWith(mockContext, '/test/data/123');
+      expect(getLogger().info).toHaveBeenCalledWith(
+        { filesSent: 3, commandName: 'file-command' },
+        'Sent download files to user'
+      );
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should handle command not found', async () => {
+      vi.mocked(getClaudeCommand).mockResolvedValue(null);
+
+      await executeClaudeCommand(mockContext, 'nonexistent-command');
+
+      expect(mockContext.reply).toHaveBeenCalledWith(
+        '❌ Command `nonexistent-command` not found.',
+        { parse_mode: 'Markdown' }
+      );
+
+      // Should not proceed with execution
+      expect(executeClaudeQuery).not.toHaveBeenCalled();
+    });
+
+    it('should handle missing user ID', async () => {
+      const mockContextNoUser = {
+        from: undefined,
+        chat: { id: 456 },
+        reply: vi.fn(),
+      } as unknown as Context;
+
+      await executeClaudeCommand(mockContextNoUser, 'test-command');
+
+      expect(mockContextNoUser.reply).toHaveBeenCalledWith('❌ Unable to identify user.');
+      expect(executeClaudeQuery).not.toHaveBeenCalled();
+    });
+
+    it('should handle Claude execution failure', async () => {
+      const mockCommand = {
+        name: 'failing-command',
+        filePath: '/test/commands/failing-command.md',
+        description: 'A command that fails',
+        content: '# Failing Command',
+      };
+
+      vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
+      vi.mocked(executeClaudeQuery).mockResolvedValue({
+        success: false,
+        output: '',
+        error: 'Claude execution failed',
+      });
+
+      await executeClaudeCommand(mockContext, 'failing-command', 'test args');
+
+      expect(sendChunkedResponse).toHaveBeenCalledWith(
+        mockContext,
+        'Claude execution failed'
+      );
+
+      expect(getLogger().info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          commandName: 'failing-command',
+          args: 'test args',
+          userId: 123,
+          success: false,
+        }),
+        'Claude command executed'
+      );
+    });
+
+    it('should handle user setup failure', async () => {
+      const mockCommand = {
+        name: 'test-command',
+        filePath: '/test/commands/test-command.md',
+        description: 'A test command',
+        content: '# Test Command',
+      };
+
+      vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
+      vi.mocked(ensureUserSetup).mockRejectedValue(new Error('Setup failed'));
+
+      await executeClaudeCommand(mockContext, 'test-command');
+
+      expect(mockContext.reply).toHaveBeenCalledWith(
+        expect.stringMatching(/❌ Failed to execute command `test-command`.*Setup failed/s),
+        { parse_mode: 'Markdown' }
+      );
+
+      expect(getLogger().error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.any(Error),
+          commandName: 'test-command',
+        }),
+        'Failed to execute Claude command'
+      );
+    });
+
+    it('should handle executeClaudeQuery exception', async () => {
+      const mockCommand = {
+        name: 'exception-command',
+        filePath: '/test/commands/exception-command.md',
+        description: 'A command that throws',
+        content: '# Exception Command',
+      };
+
+      vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
+      vi.mocked(executeClaudeQuery).mockRejectedValue(new Error('Execution threw exception'));
+
+      await executeClaudeCommand(mockContext, 'exception-command', 'test');
+
+      expect(mockContext.reply).toHaveBeenCalledWith(
+        '❌ Failed to execute command `exception-command`.\n\nError: Execution threw exception',
+        { parse_mode: 'Markdown' }
+      );
+    });
+  });
+
+  describe('Progress Handling', () => {
+    it('should show and update progress messages', async () => {
+      const mockCommand = {
+        name: 'long-command',
+        filePath: '/test/commands/long-command.md',
+        description: 'A long running command',
+        content: '# Long Command',
+      };
+
+      vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
+
+      let progressCallback: ((message: string) => Promise<void>) | undefined;
+
+      vi.mocked(executeClaudeQuery).mockImplementation(async (options) => {
+        progressCallback = options.onProgress;
+        return {
+          success: true,
+          output: 'Long command completed',
+        };
+      });
+
+      const executePromise = executeClaudeCommand(mockContext, 'long-command');
+
+      // Wait a bit for initial setup
+      await new Promise(resolve => setTimeout(resolve, 1));
+
+      // Verify initial status message
+      expect(mockContext.reply).toHaveBeenCalledWith(
+        '_Executing command..._',
+        { parse_mode: 'Markdown' }
+      );
+
+      // Test progress updates
+      if (progressCallback) {
+        await progressCallback('Reading files...');
+        await progressCallback('Processing data...');
+      }
+
+      await executePromise;
+
+      // Verify status message deletion
+      expect(mockContext.api.deleteMessage).toHaveBeenCalledWith(456, 789);
+    });
+
+    it('should handle status message edit failures gracefully', async () => {
+      const mockCommand = {
+        name: 'test-command',
+        filePath: '/test/commands/test-command.md',
+        description: 'A test command',
+        content: '# Test Command',
+      };
+
+      vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
+      vi.mocked(mockContext.api.editMessageText).mockRejectedValue(new Error('Edit failed'));
+
+      let progressCallback: ((message: string) => Promise<void>) | undefined;
+
+      vi.mocked(executeClaudeQuery).mockImplementation(async (options) => {
+        progressCallback = options.onProgress;
+        return { success: true, output: 'Done' };
+      });
+
+      const executePromise = executeClaudeCommand(mockContext, 'test-command');
+
+      await new Promise(resolve => setTimeout(resolve, 1));
+
+      // Should not throw when edit fails
+      if (progressCallback) {
+        await expect(progressCallback('Progress update')).resolves.toBeUndefined();
+      }
+
+      await executePromise;
+    });
+
+    it('should throttle progress updates', async () => {
+      const mockCommand = {
+        name: 'test-command',
+        filePath: '/test/commands/test-command.md',
+        description: 'A test command',
+        content: '# Test Command',
+      };
+
+      vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
+
+      let progressCallback: ((message: string) => Promise<void>) | undefined;
+
+      vi.mocked(executeClaudeQuery).mockImplementation(async (options) => {
+        progressCallback = options.onProgress;
+        return { success: true, output: 'Done' };
+      });
+
+      const executePromise = executeClaudeCommand(mockContext, 'test-command');
+
+      await new Promise(resolve => setTimeout(resolve, 1));
+
+      if (progressCallback) {
+        // Send multiple progress updates quickly
+        await progressCallback('Update 1');
+        await progressCallback('Update 2');
+        await progressCallback('Update 3');
+
+        // Should only edit message for the first unique update due to throttling
+        expect(mockContext.api.editMessageText).toHaveBeenCalledTimes(1);
+      }
+
+      await executePromise;
+    });
+  });
+
+  describe('Session Management', () => {
+    it('should use existing session ID', async () => {
+      const mockCommand = {
+        name: 'session-command',
+        filePath: '/test/commands/session-command.md',
+        description: 'A command with session',
+        content: '# Session Command',
+      };
+
+      vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
+      vi.mocked(getSessionId).mockResolvedValue('existing-session-456');
+      vi.mocked(executeClaudeQuery).mockResolvedValue({
+        success: true,
+        output: 'Session command result',
+      });
+
+      await executeClaudeCommand(mockContext, 'session-command');
+
+      expect(executeClaudeQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: 'existing-session-456',
+        })
+      );
+    });
+
+    it('should handle missing session ID', async () => {
+      const mockCommand = {
+        name: 'no-session-command',
+        filePath: '/test/commands/no-session-command.md',
+        description: 'A command without session',
+        content: '# No Session Command',
+      };
+
+      vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
+      vi.mocked(getSessionId).mockResolvedValue(null);
+      vi.mocked(executeClaudeQuery).mockResolvedValue({
+        success: true,
+        output: 'No session result',
+      });
+
+      await executeClaudeCommand(mockContext, 'no-session-command');
+
+      expect(executeClaudeQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: null,
+        })
+      );
+
+      // Should not try to save session if none returned
+      expect(saveSessionId).not.toHaveBeenCalled();
+    });
+
+    it('should save new session ID when returned', async () => {
+      const mockCommand = {
+        name: 'new-session-command',
+        filePath: '/test/commands/new-session-command.md',
+        description: 'A command that creates new session',
+        content: '# New Session Command',
+      };
+
+      vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
+      vi.mocked(executeClaudeQuery).mockResolvedValue({
+        success: true,
+        output: 'New session created',
+        sessionId: 'brand-new-session',
+      });
+
+      await executeClaudeCommand(mockContext, 'new-session-command');
+
+      expect(saveSessionId).toHaveBeenCalledWith('/test/data/123', 'brand-new-session');
+      expect(getLogger().debug).toHaveBeenCalledWith(
+        { sessionId: 'brand-new-session' },
+        'Session saved'
+      );
+    });
+  });
+
+  describe('Edge Cases and Input Validation', () => {
+    it('should handle commands with special characters in arguments', async () => {
+      const mockCommand = {
+        name: 'special-command',
+        filePath: '/test/commands/special-command.md',
+        description: 'Command with special chars',
+        content: '# Special Command',
+      };
+
+      vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
+      vi.mocked(executeClaudeQuery).mockResolvedValue({
+        success: true,
+        output: 'Special chars handled',
+      });
+
+      const specialArgs = 'arg with spaces "quoted arg" --flag=value $var @mention #hashtag';
+      await executeClaudeCommand(mockContext, 'special-command', specialArgs);
+
+      expect(executeClaudeQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompt: `/special-command ${specialArgs}`,
+        })
+      );
+    });
+
+    it('should handle very long command arguments', async () => {
+      const mockCommand = {
+        name: 'long-args-command',
+        filePath: '/test/commands/long-args-command.md',
+        description: 'Command with long args',
+        content: '# Long Args Command',
+      };
+
+      vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
+      vi.mocked(executeClaudeQuery).mockResolvedValue({
+        success: true,
+        output: 'Long args processed',
+      });
+
+      const longArgs = 'a'.repeat(1000);
+      await executeClaudeCommand(mockContext, 'long-args-command', longArgs);
+
+      expect(executeClaudeQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompt: `/long-args-command ${longArgs}`,
+        })
+      );
+    });
+
+    it('should handle Unicode characters in arguments', async () => {
+      const mockCommand = {
+        name: 'unicode-command',
+        filePath: '/test/commands/unicode-command.md',
+        description: 'Command with unicode',
+        content: '# Unicode Command',
+      };
+
+      vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
+      vi.mocked(executeClaudeQuery).mockResolvedValue({
+        success: true,
+        output: 'Unicode handled',
+      });
+
+      const unicodeArgs = 'Hello 世界 🌍 émojis and ñoñó';
+      await executeClaudeCommand(mockContext, 'unicode-command', unicodeArgs);
+
+      expect(executeClaudeQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompt: `/unicode-command ${unicodeArgs}`,
+        })
+      );
+    });
+  });
+});

--- a/src/claude/__tests__/commandExecutor.test.ts
+++ b/src/claude/__tests__/commandExecutor.test.ts
@@ -42,8 +42,13 @@ describe("Command Executor - Integration Tests", () => {
 
     // Mock config
     vi.mocked(getConfig).mockReturnValue({
+      telegram: { botToken: "test-token" },
+      access: { allowedUserIds: [] },
       dataDir: "/test/data",
-    } as any);
+      rateLimit: { max: 100, windowMs: 60000 },
+      logging: { level: "info" },
+      claude: { command: "claude" },
+    });
 
     // Mock logger
     vi.mocked(getLogger).mockReturnValue({
@@ -51,7 +56,7 @@ describe("Command Executor - Integration Tests", () => {
       debug: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
-    } as any);
+    } as unknown as ReturnType<typeof getLogger>);
 
     // Mock user setup functions
     vi.mocked(ensureUserSetup).mockResolvedValue();

--- a/src/claude/__tests__/commandExecutor.test.ts
+++ b/src/claude/__tests__/commandExecutor.test.ts
@@ -333,7 +333,7 @@ describe("Command Executor - Integration Tests", () => {
 
       vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
 
-      let progressCallback: ((message: string) => Promise<void>) | undefined;
+      let progressCallback: ((message: string) => void) | undefined;
 
       vi.mocked(executeClaudeQuery).mockImplementation(async (options) => {
         progressCallback = options.onProgress;
@@ -378,7 +378,7 @@ describe("Command Executor - Integration Tests", () => {
         new Error("Edit failed"),
       );
 
-      let progressCallback: ((message: string) => Promise<void>) | undefined;
+      let progressCallback: ((message: string) => void) | undefined;
 
       vi.mocked(executeClaudeQuery).mockImplementation(async (options) => {
         progressCallback = options.onProgress;
@@ -411,11 +411,11 @@ describe("Command Executor - Integration Tests", () => {
 
       // Mock Date.now to simulate time passage
       let currentTime = 1000000000; // baseline time
-      const dateNowSpy = vi.spyOn(Date, 'now').mockImplementation(() => {
+      const dateNowSpy = vi.spyOn(Date, "now").mockImplementation(() => {
         return currentTime;
       });
 
-      let progressCallback: ((message: string) => Promise<void>) | undefined;
+      let progressCallback: ((message: string) => void) | undefined;
 
       vi.mocked(executeClaudeQuery).mockImplementation(async (options) => {
         progressCallback = options.onProgress;

--- a/src/claude/__tests__/commandExecutor.test.ts
+++ b/src/claude/__tests__/commandExecutor.test.ts
@@ -1,29 +1,29 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { Context } from 'grammy';
-import { executeClaudeCommand } from '../commandExecutor.js';
-import { getClaudeCommand } from '../commands.js';
-import { executeClaudeQuery } from '../executor.js';
-import { getConfig } from '../../config.js';
-import { getLogger } from '../../logger.js';
+import type { Context } from "grammy";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getConfig } from "../../config.js";
+import { getLogger } from "../../logger.js";
+import { sendChunkedResponse } from "../../telegram/chunker.js";
+import { sendDownloadFiles } from "../../telegram/fileSender.js";
 import {
   ensureUserSetup,
   getDownloadsPath,
   getSessionId,
   saveSessionId,
-} from '../../user/setup.js';
-import { sendChunkedResponse } from '../../telegram/chunker.js';
-import { sendDownloadFiles } from '../../telegram/fileSender.js';
+} from "../../user/setup.js";
+import { executeClaudeCommand } from "../commandExecutor.js";
+import { getClaudeCommand } from "../commands.js";
+import { executeClaudeQuery } from "../executor.js";
 
 // Mock dependencies
-vi.mock('../commands.js');
-vi.mock('../executor.js');
-vi.mock('../../config.js');
-vi.mock('../../logger.js');
-vi.mock('../../user/setup.js');
-vi.mock('../../telegram/chunker.js');
-vi.mock('../../telegram/fileSender.js');
+vi.mock("../commands.js");
+vi.mock("../executor.js");
+vi.mock("../../config.js");
+vi.mock("../../logger.js");
+vi.mock("../../user/setup.js");
+vi.mock("../../telegram/chunker.js");
+vi.mock("../../telegram/fileSender.js");
 
-describe('Command Executor - Integration Tests', () => {
+describe("Command Executor - Integration Tests", () => {
   let mockContext: Context;
 
   beforeEach(() => {
@@ -42,7 +42,7 @@ describe('Command Executor - Integration Tests', () => {
 
     // Mock config
     vi.mocked(getConfig).mockReturnValue({
-      dataDir: '/test/data',
+      dataDir: "/test/data",
     } as any);
 
     // Mock logger
@@ -55,8 +55,8 @@ describe('Command Executor - Integration Tests', () => {
 
     // Mock user setup functions
     vi.mocked(ensureUserSetup).mockResolvedValue();
-    vi.mocked(getDownloadsPath).mockReturnValue('/test/downloads');
-    vi.mocked(getSessionId).mockResolvedValue('test-session');
+    vi.mocked(getDownloadsPath).mockReturnValue("/test/downloads");
+    vi.mocked(getSessionId).mockResolvedValue("test-session");
     vi.mocked(saveSessionId).mockResolvedValue();
 
     // Mock telegram functions
@@ -68,243 +68,267 @@ describe('Command Executor - Integration Tests', () => {
     vi.resetAllMocks();
   });
 
-  describe('Successful Command Execution', () => {
-    it('should execute Claude command successfully', async () => {
+  describe("Successful Command Execution", () => {
+    it("should execute Claude command successfully", async () => {
       const mockCommand = {
-        name: 'test-command',
-        filePath: '/test/commands/test-command.md',
-        description: 'A test command',
-        content: '# Test Command',
+        name: "test-command",
+        filePath: "/test/commands/test-command.md",
+        description: "A test command",
+        content: "# Test Command",
       };
 
       vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
       vi.mocked(executeClaudeQuery).mockResolvedValue({
         success: true,
-        output: 'Command executed successfully',
-        sessionId: 'new-session-123',
+        output: "Command executed successfully",
+        sessionId: "new-session-123",
       });
 
-      await executeClaudeCommand(mockContext, 'test-command', 'arg1 arg2');
+      await executeClaudeCommand(mockContext, "test-command", "arg1 arg2");
 
       // Verify command lookup
-      expect(getClaudeCommand).toHaveBeenCalledWith('test-command');
+      expect(getClaudeCommand).toHaveBeenCalledWith("test-command");
 
       // Verify user setup
-      expect(ensureUserSetup).toHaveBeenCalledWith('/test/data/123');
+      expect(ensureUserSetup).toHaveBeenCalledWith("/test/data/123");
 
       // Verify Claude execution with correct prompt
       expect(executeClaudeQuery).toHaveBeenCalledWith({
-        prompt: '/test-command arg1 arg2',
-        userDir: '/test/data/123',
-        downloadsPath: '/test/downloads',
-        sessionId: 'test-session',
+        prompt: "/test-command arg1 arg2",
+        userDir: "/test/data/123",
+        downloadsPath: "/test/downloads",
+        sessionId: "test-session",
         onProgress: expect.any(Function),
       });
 
       // Verify response
       expect(sendChunkedResponse).toHaveBeenCalledWith(
         mockContext,
-        'Command executed successfully'
+        "Command executed successfully",
       );
 
       // Verify session save
-      expect(saveSessionId).toHaveBeenCalledWith('/test/data/123', 'new-session-123');
+      expect(saveSessionId).toHaveBeenCalledWith(
+        "/test/data/123",
+        "new-session-123",
+      );
 
       // Verify files sent
-      expect(sendDownloadFiles).toHaveBeenCalledWith(mockContext, '/test/data/123');
+      expect(sendDownloadFiles).toHaveBeenCalledWith(
+        mockContext,
+        "/test/data/123",
+      );
     });
 
-    it('should handle command without arguments', async () => {
+    it("should handle command without arguments", async () => {
       const mockCommand = {
-        name: 'simple-command',
-        filePath: '/test/commands/simple-command.md',
-        description: 'A simple command',
-        content: '# Simple Command',
+        name: "simple-command",
+        filePath: "/test/commands/simple-command.md",
+        description: "A simple command",
+        content: "# Simple Command",
       };
 
       vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
       vi.mocked(executeClaudeQuery).mockResolvedValue({
         success: true,
-        output: 'Simple command result',
+        output: "Simple command result",
       });
 
-      await executeClaudeCommand(mockContext, 'simple-command');
+      await executeClaudeCommand(mockContext, "simple-command");
 
       expect(executeClaudeQuery).toHaveBeenCalledWith({
-        prompt: '/simple-command',
-        userDir: '/test/data/123',
-        downloadsPath: '/test/downloads',
-        sessionId: 'test-session',
+        prompt: "/simple-command",
+        userDir: "/test/data/123",
+        downloadsPath: "/test/downloads",
+        sessionId: "test-session",
         onProgress: expect.any(Function),
       });
     });
 
-    it('should handle command with empty arguments', async () => {
+    it("should handle command with empty arguments", async () => {
       const mockCommand = {
-        name: 'test-command',
-        filePath: '/test/commands/test-command.md',
-        description: 'A test command',
-        content: '# Test Command',
+        name: "test-command",
+        filePath: "/test/commands/test-command.md",
+        description: "A test command",
+        content: "# Test Command",
       };
 
       vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
       vi.mocked(executeClaudeQuery).mockResolvedValue({
         success: true,
-        output: 'Command result',
+        output: "Command result",
       });
 
-      await executeClaudeCommand(mockContext, 'test-command', '   \t  \n  ');
+      await executeClaudeCommand(mockContext, "test-command", "   \t  \n  ");
 
       expect(executeClaudeQuery).toHaveBeenCalledWith({
-        prompt: '/test-command',
-        userDir: '/test/data/123',
-        downloadsPath: '/test/downloads',
-        sessionId: 'test-session',
+        prompt: "/test-command",
+        userDir: "/test/data/123",
+        downloadsPath: "/test/downloads",
+        sessionId: "test-session",
         onProgress: expect.any(Function),
       });
     });
 
-    it('should handle file downloads', async () => {
+    it("should handle file downloads", async () => {
       const mockCommand = {
-        name: 'file-command',
-        filePath: '/test/commands/file-command.md',
-        description: 'A command that creates files',
-        content: '# File Command',
+        name: "file-command",
+        filePath: "/test/commands/file-command.md",
+        description: "A command that creates files",
+        content: "# File Command",
       };
 
       vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
       vi.mocked(executeClaudeQuery).mockResolvedValue({
         success: true,
-        output: 'Files created',
-        sessionId: 'session-with-files',
+        output: "Files created",
+        sessionId: "session-with-files",
       });
       vi.mocked(sendDownloadFiles).mockResolvedValue(3);
 
-      await executeClaudeCommand(mockContext, 'file-command', 'create files');
+      await executeClaudeCommand(mockContext, "file-command", "create files");
 
-      expect(sendDownloadFiles).toHaveBeenCalledWith(mockContext, '/test/data/123');
+      expect(sendDownloadFiles).toHaveBeenCalledWith(
+        mockContext,
+        "/test/data/123",
+      );
       expect(getLogger().info).toHaveBeenCalledWith(
-        { filesSent: 3, commandName: 'file-command' },
-        'Sent download files to user'
+        { filesSent: 3, commandName: "file-command" },
+        "Sent download files to user",
       );
     });
   });
 
-  describe('Error Handling', () => {
-    it('should handle command not found', async () => {
+  describe("Error Handling", () => {
+    it("should handle command not found", async () => {
       vi.mocked(getClaudeCommand).mockResolvedValue(null);
 
-      await executeClaudeCommand(mockContext, 'nonexistent-command');
+      await executeClaudeCommand(mockContext, "nonexistent-command");
 
       expect(mockContext.reply).toHaveBeenCalledWith(
-        '❌ Command `nonexistent-command` not found.',
-        { parse_mode: 'Markdown' }
+        "❌ Command `nonexistent-command` not found.",
+        { parse_mode: "Markdown" },
       );
 
       // Should not proceed with execution
       expect(executeClaudeQuery).not.toHaveBeenCalled();
     });
 
-    it('should handle missing user ID', async () => {
+    it("should handle missing user ID", async () => {
+      const mockCommand = {
+        name: "test-command",
+        filePath: "/test/commands/test-command.md",
+        description: "A test command",
+        content: "# Test Command",
+      };
+
+      vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
+
       const mockContextNoUser = {
         from: undefined,
         chat: { id: 456 },
         reply: vi.fn(),
       } as unknown as Context;
 
-      await executeClaudeCommand(mockContextNoUser, 'test-command');
+      await executeClaudeCommand(mockContextNoUser, "test-command");
 
-      expect(mockContextNoUser.reply).toHaveBeenCalledWith('❌ Unable to identify user.');
+      expect(mockContextNoUser.reply).toHaveBeenCalledWith(
+        "❌ Unable to identify user.",
+      );
       expect(executeClaudeQuery).not.toHaveBeenCalled();
     });
 
-    it('should handle Claude execution failure', async () => {
+    it("should handle Claude execution failure", async () => {
       const mockCommand = {
-        name: 'failing-command',
-        filePath: '/test/commands/failing-command.md',
-        description: 'A command that fails',
-        content: '# Failing Command',
+        name: "failing-command",
+        filePath: "/test/commands/failing-command.md",
+        description: "A command that fails",
+        content: "# Failing Command",
       };
 
       vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
       vi.mocked(executeClaudeQuery).mockResolvedValue({
         success: false,
-        output: '',
-        error: 'Claude execution failed',
+        output: "",
+        error: "Claude execution failed",
       });
 
-      await executeClaudeCommand(mockContext, 'failing-command', 'test args');
+      await executeClaudeCommand(mockContext, "failing-command", "test args");
 
       expect(sendChunkedResponse).toHaveBeenCalledWith(
         mockContext,
-        'Claude execution failed'
+        "Claude execution failed",
       );
 
       expect(getLogger().info).toHaveBeenCalledWith(
         expect.objectContaining({
-          commandName: 'failing-command',
-          args: 'test args',
+          commandName: "failing-command",
+          args: "test args",
           userId: 123,
           success: false,
         }),
-        'Claude command executed'
+        "Claude command executed",
       );
     });
 
-    it('should handle user setup failure', async () => {
+    it("should handle user setup failure", async () => {
       const mockCommand = {
-        name: 'test-command',
-        filePath: '/test/commands/test-command.md',
-        description: 'A test command',
-        content: '# Test Command',
+        name: "test-command",
+        filePath: "/test/commands/test-command.md",
+        description: "A test command",
+        content: "# Test Command",
       };
 
       vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
-      vi.mocked(ensureUserSetup).mockRejectedValue(new Error('Setup failed'));
+      vi.mocked(ensureUserSetup).mockRejectedValue(new Error("Setup failed"));
 
-      await executeClaudeCommand(mockContext, 'test-command');
+      await executeClaudeCommand(mockContext, "test-command");
 
       expect(mockContext.reply).toHaveBeenCalledWith(
-        expect.stringMatching(/❌ Failed to execute command `test-command`.*Setup failed/s),
-        { parse_mode: 'Markdown' }
+        expect.stringMatching(
+          /❌ Failed to execute command `test-command`.*Setup failed/s,
+        ),
+        { parse_mode: "Markdown" },
       );
 
       expect(getLogger().error).toHaveBeenCalledWith(
         expect.objectContaining({
           error: expect.any(Error),
-          commandName: 'test-command',
+          commandName: "test-command",
         }),
-        'Failed to execute Claude command'
+        "Failed to execute Claude command",
       );
     });
 
-    it('should handle executeClaudeQuery exception', async () => {
+    it("should handle executeClaudeQuery exception", async () => {
       const mockCommand = {
-        name: 'exception-command',
-        filePath: '/test/commands/exception-command.md',
-        description: 'A command that throws',
-        content: '# Exception Command',
+        name: "exception-command",
+        filePath: "/test/commands/exception-command.md",
+        description: "A command that throws",
+        content: "# Exception Command",
       };
 
       vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
-      vi.mocked(executeClaudeQuery).mockRejectedValue(new Error('Execution threw exception'));
+      vi.mocked(executeClaudeQuery).mockRejectedValue(
+        new Error("Execution threw exception"),
+      );
 
-      await executeClaudeCommand(mockContext, 'exception-command', 'test');
+      await executeClaudeCommand(mockContext, "exception-command", "test");
 
       expect(mockContext.reply).toHaveBeenCalledWith(
-        '❌ Failed to execute command `exception-command`.\n\nError: Execution threw exception',
-        { parse_mode: 'Markdown' }
+        "❌ Failed to execute command `exception-command`.\n\nError: Execution threw exception",
+        { parse_mode: "Markdown" },
       );
     });
   });
 
-  describe('Progress Handling', () => {
-    it('should show and update progress messages', async () => {
+  describe("Progress Handling", () => {
+    it("should show and update progress messages", async () => {
       const mockCommand = {
-        name: 'long-command',
-        filePath: '/test/commands/long-command.md',
-        description: 'A long running command',
-        content: '# Long Command',
+        name: "long-command",
+        filePath: "/test/commands/long-command.md",
+        description: "A long running command",
+        content: "# Long Command",
       };
 
       vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
@@ -315,25 +339,24 @@ describe('Command Executor - Integration Tests', () => {
         progressCallback = options.onProgress;
         return {
           success: true,
-          output: 'Long command completed',
+          output: "Long command completed",
         };
       });
 
-      const executePromise = executeClaudeCommand(mockContext, 'long-command');
+      const executePromise = executeClaudeCommand(mockContext, "long-command");
 
       // Wait a bit for initial setup
-      await new Promise(resolve => setTimeout(resolve, 1));
+      await new Promise((resolve) => setTimeout(resolve, 1));
 
       // Verify initial status message
-      expect(mockContext.reply).toHaveBeenCalledWith(
-        '_Executing command..._',
-        { parse_mode: 'Markdown' }
-      );
+      expect(mockContext.reply).toHaveBeenCalledWith("_Executing command..._", {
+        parse_mode: "Markdown",
+      });
 
       // Test progress updates
       if (progressCallback) {
-        await progressCallback('Reading files...');
-        await progressCallback('Processing data...');
+        await progressCallback("Reading files...");
+        await progressCallback("Processing data...");
       }
 
       await executePromise;
@@ -342,218 +365,244 @@ describe('Command Executor - Integration Tests', () => {
       expect(mockContext.api.deleteMessage).toHaveBeenCalledWith(456, 789);
     });
 
-    it('should handle status message edit failures gracefully', async () => {
+    it("should handle status message edit failures gracefully", async () => {
       const mockCommand = {
-        name: 'test-command',
-        filePath: '/test/commands/test-command.md',
-        description: 'A test command',
-        content: '# Test Command',
+        name: "test-command",
+        filePath: "/test/commands/test-command.md",
+        description: "A test command",
+        content: "# Test Command",
       };
 
       vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
-      vi.mocked(mockContext.api.editMessageText).mockRejectedValue(new Error('Edit failed'));
+      vi.mocked(mockContext.api.editMessageText).mockRejectedValue(
+        new Error("Edit failed"),
+      );
 
       let progressCallback: ((message: string) => Promise<void>) | undefined;
 
       vi.mocked(executeClaudeQuery).mockImplementation(async (options) => {
         progressCallback = options.onProgress;
-        return { success: true, output: 'Done' };
+        return { success: true, output: "Done" };
       });
 
-      const executePromise = executeClaudeCommand(mockContext, 'test-command');
+      const executePromise = executeClaudeCommand(mockContext, "test-command");
 
-      await new Promise(resolve => setTimeout(resolve, 1));
+      await new Promise((resolve) => setTimeout(resolve, 1));
 
       // Should not throw when edit fails
       if (progressCallback) {
-        await expect(progressCallback('Progress update')).resolves.toBeUndefined();
+        await expect(
+          progressCallback("Progress update"),
+        ).resolves.toBeUndefined();
       }
 
       await executePromise;
     });
 
-    it('should throttle progress updates', async () => {
+    it("should throttle progress updates", async () => {
       const mockCommand = {
-        name: 'test-command',
-        filePath: '/test/commands/test-command.md',
-        description: 'A test command',
-        content: '# Test Command',
+        name: "test-command",
+        filePath: "/test/commands/test-command.md",
+        description: "A test command",
+        content: "# Test Command",
       };
 
       vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
+
+      // Mock Date.now to simulate time passage
+      let currentTime = 1000000000; // baseline time
+      const dateNowSpy = vi.spyOn(Date, 'now').mockImplementation(() => {
+        return currentTime;
+      });
 
       let progressCallback: ((message: string) => Promise<void>) | undefined;
 
       vi.mocked(executeClaudeQuery).mockImplementation(async (options) => {
         progressCallback = options.onProgress;
-        return { success: true, output: 'Done' };
+        return { success: true, output: "Done" };
       });
 
-      const executePromise = executeClaudeCommand(mockContext, 'test-command');
+      const executePromise = executeClaudeCommand(mockContext, "test-command");
 
-      await new Promise(resolve => setTimeout(resolve, 1));
+      await new Promise((resolve) => setTimeout(resolve, 1));
 
       if (progressCallback) {
-        // Send multiple progress updates quickly
-        await progressCallback('Update 1');
-        await progressCallback('Update 2');
-        await progressCallback('Update 3');
+        // First update: advance time by 3000ms (> 2000ms threshold) and different message
+        currentTime += 3000;
+        await progressCallback("Update 1");
 
-        // Should only edit message for the first unique update due to throttling
+        // Subsequent updates: rapid fire (no time advancement) should be throttled
+        await progressCallback("Update 2");
+        await progressCallback("Update 3");
+
+        // Should only edit message once due to throttling
         expect(mockContext.api.editMessageText).toHaveBeenCalledTimes(1);
+        expect(mockContext.api.editMessageText).toHaveBeenCalledWith(
+          456,
+          789,
+          "_Update 1_",
+          { parse_mode: "Markdown" },
+        );
       }
 
       await executePromise;
+
+      // Restore Date.now
+      dateNowSpy.mockRestore();
     });
   });
 
-  describe('Session Management', () => {
-    it('should use existing session ID', async () => {
+  describe("Session Management", () => {
+    it("should use existing session ID", async () => {
       const mockCommand = {
-        name: 'session-command',
-        filePath: '/test/commands/session-command.md',
-        description: 'A command with session',
-        content: '# Session Command',
+        name: "session-command",
+        filePath: "/test/commands/session-command.md",
+        description: "A command with session",
+        content: "# Session Command",
       };
 
       vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
-      vi.mocked(getSessionId).mockResolvedValue('existing-session-456');
+      vi.mocked(getSessionId).mockResolvedValue("existing-session-456");
       vi.mocked(executeClaudeQuery).mockResolvedValue({
         success: true,
-        output: 'Session command result',
+        output: "Session command result",
       });
 
-      await executeClaudeCommand(mockContext, 'session-command');
+      await executeClaudeCommand(mockContext, "session-command");
 
       expect(executeClaudeQuery).toHaveBeenCalledWith(
         expect.objectContaining({
-          sessionId: 'existing-session-456',
-        })
+          sessionId: "existing-session-456",
+        }),
       );
     });
 
-    it('should handle missing session ID', async () => {
+    it("should handle missing session ID", async () => {
       const mockCommand = {
-        name: 'no-session-command',
-        filePath: '/test/commands/no-session-command.md',
-        description: 'A command without session',
-        content: '# No Session Command',
+        name: "no-session-command",
+        filePath: "/test/commands/no-session-command.md",
+        description: "A command without session",
+        content: "# No Session Command",
       };
 
       vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
       vi.mocked(getSessionId).mockResolvedValue(null);
       vi.mocked(executeClaudeQuery).mockResolvedValue({
         success: true,
-        output: 'No session result',
+        output: "No session result",
       });
 
-      await executeClaudeCommand(mockContext, 'no-session-command');
+      await executeClaudeCommand(mockContext, "no-session-command");
 
       expect(executeClaudeQuery).toHaveBeenCalledWith(
         expect.objectContaining({
           sessionId: null,
-        })
+        }),
       );
 
       // Should not try to save session if none returned
       expect(saveSessionId).not.toHaveBeenCalled();
     });
 
-    it('should save new session ID when returned', async () => {
+    it("should save new session ID when returned", async () => {
       const mockCommand = {
-        name: 'new-session-command',
-        filePath: '/test/commands/new-session-command.md',
-        description: 'A command that creates new session',
-        content: '# New Session Command',
+        name: "new-session-command",
+        filePath: "/test/commands/new-session-command.md",
+        description: "A command that creates new session",
+        content: "# New Session Command",
       };
 
       vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
       vi.mocked(executeClaudeQuery).mockResolvedValue({
         success: true,
-        output: 'New session created',
-        sessionId: 'brand-new-session',
+        output: "New session created",
+        sessionId: "brand-new-session",
       });
 
-      await executeClaudeCommand(mockContext, 'new-session-command');
+      await executeClaudeCommand(mockContext, "new-session-command");
 
-      expect(saveSessionId).toHaveBeenCalledWith('/test/data/123', 'brand-new-session');
+      expect(saveSessionId).toHaveBeenCalledWith(
+        "/test/data/123",
+        "brand-new-session",
+      );
       expect(getLogger().debug).toHaveBeenCalledWith(
-        { sessionId: 'brand-new-session' },
-        'Session saved'
+        { sessionId: "brand-new-session" },
+        "Session saved",
       );
     });
   });
 
-  describe('Edge Cases and Input Validation', () => {
-    it('should handle commands with special characters in arguments', async () => {
+  describe("Edge Cases and Input Validation", () => {
+    it("should handle commands with special characters in arguments", async () => {
       const mockCommand = {
-        name: 'special-command',
-        filePath: '/test/commands/special-command.md',
-        description: 'Command with special chars',
-        content: '# Special Command',
+        name: "special-command",
+        filePath: "/test/commands/special-command.md",
+        description: "Command with special chars",
+        content: "# Special Command",
       };
 
       vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
       vi.mocked(executeClaudeQuery).mockResolvedValue({
         success: true,
-        output: 'Special chars handled',
+        output: "Special chars handled",
       });
 
-      const specialArgs = 'arg with spaces "quoted arg" --flag=value $var @mention #hashtag';
-      await executeClaudeCommand(mockContext, 'special-command', specialArgs);
+      const specialArgs =
+        'arg with spaces "quoted arg" --flag=value $var @mention #hashtag';
+      await executeClaudeCommand(mockContext, "special-command", specialArgs);
 
       expect(executeClaudeQuery).toHaveBeenCalledWith(
         expect.objectContaining({
           prompt: `/special-command ${specialArgs}`,
-        })
+        }),
       );
     });
 
-    it('should handle very long command arguments', async () => {
+    it("should handle very long command arguments", async () => {
       const mockCommand = {
-        name: 'long-args-command',
-        filePath: '/test/commands/long-args-command.md',
-        description: 'Command with long args',
-        content: '# Long Args Command',
+        name: "long-args-command",
+        filePath: "/test/commands/long-args-command.md",
+        description: "Command with long args",
+        content: "# Long Args Command",
       };
 
       vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
       vi.mocked(executeClaudeQuery).mockResolvedValue({
         success: true,
-        output: 'Long args processed',
+        output: "Long args processed",
       });
 
-      const longArgs = 'a'.repeat(1000);
-      await executeClaudeCommand(mockContext, 'long-args-command', longArgs);
+      const longArgs = "a".repeat(1000);
+      await executeClaudeCommand(mockContext, "long-args-command", longArgs);
 
       expect(executeClaudeQuery).toHaveBeenCalledWith(
         expect.objectContaining({
           prompt: `/long-args-command ${longArgs}`,
-        })
+        }),
       );
     });
 
-    it('should handle Unicode characters in arguments', async () => {
+    it("should handle Unicode characters in arguments", async () => {
       const mockCommand = {
-        name: 'unicode-command',
-        filePath: '/test/commands/unicode-command.md',
-        description: 'Command with unicode',
-        content: '# Unicode Command',
+        name: "unicode-command",
+        filePath: "/test/commands/unicode-command.md",
+        description: "Command with unicode",
+        content: "# Unicode Command",
       };
 
       vi.mocked(getClaudeCommand).mockResolvedValue(mockCommand);
       vi.mocked(executeClaudeQuery).mockResolvedValue({
         success: true,
-        output: 'Unicode handled',
+        output: "Unicode handled",
       });
 
-      const unicodeArgs = 'Hello 世界 🌍 émojis and ñoñó';
-      await executeClaudeCommand(mockContext, 'unicode-command', unicodeArgs);
+      const unicodeArgs = "Hello 世界 🌍 émojis and ñoñó";
+      await executeClaudeCommand(mockContext, "unicode-command", unicodeArgs);
 
       expect(executeClaudeQuery).toHaveBeenCalledWith(
         expect.objectContaining({
           prompt: `/unicode-command ${unicodeArgs}`,
-        })
+        }),
       );
     });
   });

--- a/src/claude/__tests__/commands.improved.test.ts
+++ b/src/claude/__tests__/commands.improved.test.ts
@@ -32,7 +32,7 @@ describe("Improved Claude Commands - Performance and Validation", () => {
       debug: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
-    } as any);
+    } as unknown as ReturnType<typeof getLogger>);
   });
 
   afterEach(() => {

--- a/src/claude/__tests__/commands.improved.test.ts
+++ b/src/claude/__tests__/commands.improved.test.ts
@@ -1,0 +1,363 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { join } from 'node:path';
+import { getWorkingDirectory } from '../../config.js';
+import { getLogger } from '../../logger.js';
+
+// Mock dependencies
+vi.mock('../../config.js');
+vi.mock('../../logger.js');
+
+// Mock fs operations at the top level
+const mockReaddir = vi.fn();
+const mockReadFile = vi.fn();
+
+vi.mock('node:fs/promises', () => ({
+  readdir: mockReaddir,
+  readFile: mockReadFile,
+}));
+
+describe('Improved Claude Commands - Performance and Validation', () => {
+  const testWorkingDir = '/test/working';
+  const testCommandsDir = join(testWorkingDir, '.claude', 'commands');
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Mock working directory
+    vi.mocked(getWorkingDirectory).mockReturnValue(testWorkingDir);
+
+    // Mock logger
+    vi.mocked(getLogger).mockReturnValue({
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as any);
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('Command Validation', () => {
+    it('should reject commands that conflict with built-ins', async () => {
+      // Import after mocks are set up
+      const { discoverClaudeCommands, clearCommandsCache } = await import('../commands.improved.js');
+
+      clearCommandsCache(); // Clear cache before test
+
+      // Setup mock data with conflicting command names
+      mockReaddir.mockResolvedValue(['start.md', 'help.md', 'valid-command.md']);
+
+      mockReadFile
+        .mockResolvedValueOnce(`---
+description: This conflicts with built-in start command
+---
+# Start Command`)
+        .mockResolvedValueOnce(`---
+description: This conflicts with built-in help command
+---
+# Help Command`)
+        .mockResolvedValueOnce(`---
+description: This is a valid command
+---
+# Valid Command`);
+
+      const commands = await discoverClaudeCommands();
+
+      expect(commands).toHaveLength(3);
+
+      // Check that built-in conflicts are marked as invalid
+      const startCommand = commands.find(cmd => cmd.name === 'start');
+      const helpCommand = commands.find(cmd => cmd.name === 'help');
+      const validCommand = commands.find(cmd => cmd.name === 'valid-command');
+
+      expect(startCommand?.isValid).toBe(false);
+      expect(startCommand?.validationError).toContain('conflicts with built-in command');
+
+      expect(helpCommand?.isValid).toBe(false);
+      expect(helpCommand?.validationError).toContain('conflicts with built-in command');
+
+      expect(validCommand?.isValid).toBe(true);
+      expect(validCommand?.validationError).toBeUndefined();
+    });
+
+    it('should reject commands with invalid characters', async () => {
+      const { discoverClaudeCommands, clearCommandsCache } = await import('../commands.improved.js');
+
+      clearCommandsCache();
+
+      mockReaddir.mockResolvedValue([
+        'valid-command_123.md',
+        'invalid@command.md',
+        'another#invalid.md',
+        'valid.dots.command.md'
+      ]);
+
+      mockReadFile
+        .mockResolvedValue('# Test Command')
+        .mockResolvedValue('# Test Command')
+        .mockResolvedValue('# Test Command')
+        .mockResolvedValue('# Test Command');
+
+      const commands = await discoverClaudeCommands();
+
+      expect(commands).toHaveLength(4);
+
+      const validCommand1 = commands.find(cmd => cmd.name === 'valid-command_123');
+      const invalidCommand1 = commands.find(cmd => cmd.name === 'invalid@command');
+      const invalidCommand2 = commands.find(cmd => cmd.name === 'another#invalid');
+      const validCommand2 = commands.find(cmd => cmd.name === 'valid.dots.command');
+
+      expect(validCommand1?.isValid).toBe(true);
+      expect(invalidCommand1?.isValid).toBe(false);
+      expect(invalidCommand1?.validationError).toContain('invalid characters');
+      expect(invalidCommand2?.isValid).toBe(false);
+      expect(invalidCommand2?.validationError).toContain('invalid characters');
+      expect(validCommand2?.isValid).toBe(true);
+    });
+
+    it('should reject commands with invalid length or format', async () => {
+      const { discoverClaudeCommands, clearCommandsCache } = await import('../commands.improved.js');
+
+      clearCommandsCache();
+
+      const longCommandName = 'a'.repeat(70); // Too long
+      mockReaddir.mockResolvedValue([
+        '.invalid-start.md',
+        'invalid-end-.md',
+        `${longCommandName}.md`,
+        'valid-command.md'
+      ]);
+
+      mockReadFile
+        .mockResolvedValue('# Test Command')
+        .mockResolvedValue('# Test Command')
+        .mockResolvedValue('# Test Command')
+        .mockResolvedValue('# Test Command');
+
+      const commands = await discoverClaudeCommands();
+
+      expect(commands).toHaveLength(4);
+
+      const invalidStart = commands.find(cmd => cmd.name === '.invalid-start');
+      const invalidEnd = commands.find(cmd => cmd.name === 'invalid-end-');
+      const tooLong = commands.find(cmd => cmd.name === longCommandName);
+      const valid = commands.find(cmd => cmd.name === 'valid-command');
+
+      expect(invalidStart?.isValid).toBe(false);
+      expect(invalidStart?.validationError).toContain('cannot start or end');
+
+      expect(invalidEnd?.isValid).toBe(false);
+      expect(invalidEnd?.validationError).toContain('cannot start or end');
+
+      expect(tooLong?.isValid).toBe(false);
+      expect(tooLong?.validationError).toContain('too long');
+
+      expect(valid?.isValid).toBe(true);
+    });
+
+    it('should sanitize command descriptions', async () => {
+      const { discoverClaudeCommands, clearCommandsCache } = await import('../commands.improved.js');
+
+      clearCommandsCache();
+
+      mockReaddir.mockResolvedValue(['sanitize-test.md']);
+      mockReadFile.mockResolvedValue(`---
+description: "Command with <script>alert('xss')</script> and control chars \x00\x08"
+---
+# Sanitize Test`);
+
+      const commands = await discoverClaudeCommands();
+
+      expect(commands).toHaveLength(1);
+      expect(commands[0].description).not.toContain('<script>');
+      expect(commands[0].description).not.toContain('\x00');
+      expect(commands[0].description).not.toContain('\x08');
+      // Should have removed < and > characters and control chars
+      expect(commands[0].description).toContain("alert('xss')");
+      expect(commands[0].description).not.toContain('<');
+      expect(commands[0].description).not.toContain('>');
+    });
+
+    it('should handle malformed frontmatter gracefully', async () => {
+      const { discoverClaudeCommands, clearCommandsCache } = await import('../commands.improved.js');
+
+      clearCommandsCache();
+
+      mockReaddir.mockResolvedValue(['malformed.md']);
+      mockReadFile.mockResolvedValue(`---
+invalid: yaml: syntax: {[}]
+description without colon
+malformed structure
+---
+# Malformed Command`);
+
+      const commands = await discoverClaudeCommands();
+
+      expect(commands).toHaveLength(1);
+      expect(commands[0].description).toBeUndefined();
+      expect(commands[0].isValid).toBe(true); // Still valid command name
+
+      // Note: The simple parser doesn't actually throw errors for malformed frontmatter,
+      // it just silently ignores fields it can't parse. This is by design for robustness.
+    });
+  });
+
+  describe('Caching Functionality', () => {
+    it('should cache discovered commands', async () => {
+      const { discoverClaudeCommands, clearCommandsCache } = await import('../commands.improved.js');
+
+      clearCommandsCache();
+
+      mockReaddir.mockResolvedValue(['cached-command.md']);
+      mockReadFile.mockResolvedValue('# Cached Command');
+
+      // First call should read from filesystem
+      const commands1 = await discoverClaudeCommands();
+      expect(mockReaddir).toHaveBeenCalledTimes(1);
+      expect(mockReadFile).toHaveBeenCalledTimes(1);
+
+      // Second call should use cache
+      const commands2 = await discoverClaudeCommands();
+      expect(mockReaddir).toHaveBeenCalledTimes(1); // No additional calls
+      expect(mockReadFile).toHaveBeenCalledTimes(1); // No additional calls
+
+      expect(commands1).toEqual(commands2);
+      expect(getLogger().debug).toHaveBeenCalledWith(
+        expect.objectContaining({ cached: true }),
+        'Using cached Claude commands'
+      );
+    });
+
+    it('should clear cache when requested', async () => {
+      const { discoverClaudeCommands, clearCommandsCache } = await import('../commands.improved.js');
+
+      clearCommandsCache();
+
+      mockReaddir.mockResolvedValue(['test-command.md']);
+      mockReadFile.mockResolvedValue('# Test Command');
+
+      // First discovery
+      await discoverClaudeCommands();
+      expect(mockReaddir).toHaveBeenCalledTimes(1);
+
+      // Clear cache
+      clearCommandsCache();
+
+      // Second discovery should re-read filesystem
+      await discoverClaudeCommands();
+      expect(mockReaddir).toHaveBeenCalledTimes(2);
+    });
+
+    it('should cache empty results when no commands directory exists', async () => {
+      const { discoverClaudeCommands, clearCommandsCache } = await import('../commands.improved.js');
+
+      clearCommandsCache();
+
+      mockReaddir.mockRejectedValue(new Error('ENOENT: no such file or directory'));
+
+      // First call should attempt to read directory
+      const commands1 = await discoverClaudeCommands();
+      expect(commands1).toHaveLength(0);
+      expect(mockReaddir).toHaveBeenCalledTimes(1);
+
+      // Second call should use cached empty result
+      const commands2 = await discoverClaudeCommands();
+      expect(commands2).toHaveLength(0);
+      expect(mockReaddir).toHaveBeenCalledTimes(1); // No additional filesystem call
+    });
+  });
+
+  describe('Filtered Command Access', () => {
+    it('should return only valid commands', async () => {
+      const { getValidClaudeCommands, clearCommandsCache } = await import('../commands.improved.js');
+
+      clearCommandsCache();
+
+      mockReaddir.mockResolvedValue(['valid.md', 'start.md', 'another-valid.md']);
+      mockReadFile
+        .mockResolvedValueOnce('# Valid Command')
+        .mockResolvedValueOnce('# Start Command (conflicts)')
+        .mockResolvedValueOnce('# Another Valid Command');
+
+      const validCommands = await getValidClaudeCommands();
+
+      expect(validCommands).toHaveLength(2);
+      expect(validCommands.map(cmd => cmd.name)).toEqual(['valid', 'another-valid']);
+      expect(validCommands.every(cmd => cmd.isValid)).toBe(true);
+    });
+
+    it('should get specific valid command by name', async () => {
+      const { getValidClaudeCommand, clearCommandsCache } = await import('../commands.improved.js');
+
+      clearCommandsCache();
+
+      mockReaddir.mockResolvedValue(['valid.md', 'start.md']);
+      mockReadFile
+        .mockResolvedValueOnce('# Valid Command')
+        .mockResolvedValueOnce('# Start Command');
+
+      const validCommand = await getValidClaudeCommand('valid');
+      const invalidCommand = await getValidClaudeCommand('start');
+
+      expect(validCommand?.name).toBe('valid');
+      expect(validCommand?.isValid).toBe(true);
+      expect(invalidCommand).toBeNull(); // Invalid command should return null
+    });
+
+    it('should get validation errors for debugging', async () => {
+      const { getCommandValidationErrors, clearCommandsCache } = await import('../commands.improved.js');
+
+      clearCommandsCache();
+
+      mockReaddir.mockResolvedValue(['start.md', 'help.md', 'invalid@name.md']);
+      mockReadFile
+        .mockResolvedValue('# Command')
+        .mockResolvedValue('# Command')
+        .mockResolvedValue('# Command');
+
+      const errors = await getCommandValidationErrors();
+
+      expect(errors).toHaveLength(3);
+      expect(errors.map(e => e.name)).toEqual(expect.arrayContaining(['start', 'help', 'invalid@name']));
+      expect(errors.every(e => e.error)).toBeTruthy();
+    });
+  });
+
+  describe('Integration with Existing getClaudeCommand', () => {
+    it('should maintain backward compatibility with getClaudeCommand', async () => {
+      const { getClaudeCommand, clearCommandsCache } = await import('../commands.improved.js');
+
+      clearCommandsCache();
+
+      mockReaddir.mockResolvedValue(['test.md', 'start.md']);
+      mockReadFile
+        .mockResolvedValueOnce('# Test Command')
+        .mockResolvedValueOnce('# Start Command');
+
+      const validCommand = await getClaudeCommand('test');
+      const invalidCommand = await getClaudeCommand('start');
+
+      // Should return command objects regardless of validity
+      expect(validCommand?.name).toBe('test');
+      expect(validCommand?.isValid).toBe(true);
+
+      expect(invalidCommand?.name).toBe('start');
+      expect(invalidCommand?.isValid).toBe(false);
+    });
+
+    it('should return null for non-existent commands', async () => {
+      const { getClaudeCommand, clearCommandsCache } = await import('../commands.improved.js');
+
+      clearCommandsCache();
+
+      mockReaddir.mockResolvedValue(['existing.md']);
+      mockReadFile.mockResolvedValue('# Existing Command');
+
+      const nonExistent = await getClaudeCommand('non-existent');
+
+      expect(nonExistent).toBeNull();
+    });
+  });
+});

--- a/src/claude/__tests__/commands.improved.test.ts
+++ b/src/claude/__tests__/commands.improved.test.ts
@@ -1,24 +1,24 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { join } from 'node:path';
-import { getWorkingDirectory } from '../../config.js';
-import { getLogger } from '../../logger.js';
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getWorkingDirectory } from "../../config.js";
+import { getLogger } from "../../logger.js";
 
 // Mock dependencies
-vi.mock('../../config.js');
-vi.mock('../../logger.js');
+vi.mock("../../config.js");
+vi.mock("../../logger.js");
 
 // Mock fs operations at the top level
 const mockReaddir = vi.fn();
 const mockReadFile = vi.fn();
 
-vi.mock('node:fs/promises', () => ({
+vi.mock("node:fs/promises", () => ({
   readdir: mockReaddir,
   readFile: mockReadFile,
 }));
 
-describe('Improved Claude Commands - Performance and Validation', () => {
-  const testWorkingDir = '/test/working';
-  const testCommandsDir = join(testWorkingDir, '.claude', 'commands');
+describe("Improved Claude Commands - Performance and Validation", () => {
+  const testWorkingDir = "/test/working";
+  const testCommandsDir = join(testWorkingDir, ".claude", "commands");
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -39,15 +39,21 @@ describe('Improved Claude Commands - Performance and Validation', () => {
     vi.resetAllMocks();
   });
 
-  describe('Command Validation', () => {
-    it('should reject commands that conflict with built-ins', async () => {
+  describe("Command Validation", () => {
+    it("should reject commands that conflict with built-ins", async () => {
       // Import after mocks are set up
-      const { discoverClaudeCommands, clearCommandsCache } = await import('../commands.improved.js');
+      const { discoverClaudeCommands, clearCommandsCache } = await import(
+        "../commands.improved.js"
+      );
 
       clearCommandsCache(); // Clear cache before test
 
       // Setup mock data with conflicting command names
-      mockReaddir.mockResolvedValue(['start.md', 'help.md', 'valid-command.md']);
+      mockReaddir.mockResolvedValue([
+        "start.md",
+        "help.md",
+        "valid-command.md",
+      ]);
 
       mockReadFile
         .mockResolvedValueOnce(`---
@@ -68,101 +74,121 @@ description: This is a valid command
       expect(commands).toHaveLength(3);
 
       // Check that built-in conflicts are marked as invalid
-      const startCommand = commands.find(cmd => cmd.name === 'start');
-      const helpCommand = commands.find(cmd => cmd.name === 'help');
-      const validCommand = commands.find(cmd => cmd.name === 'valid-command');
+      const startCommand = commands.find((cmd) => cmd.name === "start");
+      const helpCommand = commands.find((cmd) => cmd.name === "help");
+      const validCommand = commands.find((cmd) => cmd.name === "valid-command");
 
       expect(startCommand?.isValid).toBe(false);
-      expect(startCommand?.validationError).toContain('conflicts with built-in command');
+      expect(startCommand?.validationError).toContain(
+        "conflicts with built-in command",
+      );
 
       expect(helpCommand?.isValid).toBe(false);
-      expect(helpCommand?.validationError).toContain('conflicts with built-in command');
+      expect(helpCommand?.validationError).toContain(
+        "conflicts with built-in command",
+      );
 
       expect(validCommand?.isValid).toBe(true);
       expect(validCommand?.validationError).toBeUndefined();
     });
 
-    it('should reject commands with invalid characters', async () => {
-      const { discoverClaudeCommands, clearCommandsCache } = await import('../commands.improved.js');
+    it("should reject commands with invalid characters", async () => {
+      const { discoverClaudeCommands, clearCommandsCache } = await import(
+        "../commands.improved.js"
+      );
 
       clearCommandsCache();
 
       mockReaddir.mockResolvedValue([
-        'valid-command_123.md',
-        'invalid@command.md',
-        'another#invalid.md',
-        'valid.dots.command.md'
+        "valid-command_123.md",
+        "invalid@command.md",
+        "another#invalid.md",
+        "valid.dots.command.md",
       ]);
 
       mockReadFile
-        .mockResolvedValue('# Test Command')
-        .mockResolvedValue('# Test Command')
-        .mockResolvedValue('# Test Command')
-        .mockResolvedValue('# Test Command');
+        .mockResolvedValue("# Test Command")
+        .mockResolvedValue("# Test Command")
+        .mockResolvedValue("# Test Command")
+        .mockResolvedValue("# Test Command");
 
       const commands = await discoverClaudeCommands();
 
       expect(commands).toHaveLength(4);
 
-      const validCommand1 = commands.find(cmd => cmd.name === 'valid-command_123');
-      const invalidCommand1 = commands.find(cmd => cmd.name === 'invalid@command');
-      const invalidCommand2 = commands.find(cmd => cmd.name === 'another#invalid');
-      const validCommand2 = commands.find(cmd => cmd.name === 'valid.dots.command');
+      const validCommand1 = commands.find(
+        (cmd) => cmd.name === "valid-command_123",
+      );
+      const invalidCommand1 = commands.find(
+        (cmd) => cmd.name === "invalid@command",
+      );
+      const invalidCommand2 = commands.find(
+        (cmd) => cmd.name === "another#invalid",
+      );
+      const validCommand2 = commands.find(
+        (cmd) => cmd.name === "valid.dots.command",
+      );
 
       expect(validCommand1?.isValid).toBe(true);
       expect(invalidCommand1?.isValid).toBe(false);
-      expect(invalidCommand1?.validationError).toContain('invalid characters');
+      expect(invalidCommand1?.validationError).toContain("invalid characters");
       expect(invalidCommand2?.isValid).toBe(false);
-      expect(invalidCommand2?.validationError).toContain('invalid characters');
+      expect(invalidCommand2?.validationError).toContain("invalid characters");
       expect(validCommand2?.isValid).toBe(true);
     });
 
-    it('should reject commands with invalid length or format', async () => {
-      const { discoverClaudeCommands, clearCommandsCache } = await import('../commands.improved.js');
+    it("should reject commands with invalid length or format", async () => {
+      const { discoverClaudeCommands, clearCommandsCache } = await import(
+        "../commands.improved.js"
+      );
 
       clearCommandsCache();
 
-      const longCommandName = 'a'.repeat(70); // Too long
+      const longCommandName = "a".repeat(70); // Too long
       mockReaddir.mockResolvedValue([
-        '.invalid-start.md',
-        'invalid-end-.md',
+        ".invalid-start.md",
+        "invalid-end-.md",
         `${longCommandName}.md`,
-        'valid-command.md'
+        "valid-command.md",
       ]);
 
       mockReadFile
-        .mockResolvedValue('# Test Command')
-        .mockResolvedValue('# Test Command')
-        .mockResolvedValue('# Test Command')
-        .mockResolvedValue('# Test Command');
+        .mockResolvedValue("# Test Command")
+        .mockResolvedValue("# Test Command")
+        .mockResolvedValue("# Test Command")
+        .mockResolvedValue("# Test Command");
 
       const commands = await discoverClaudeCommands();
 
       expect(commands).toHaveLength(4);
 
-      const invalidStart = commands.find(cmd => cmd.name === '.invalid-start');
-      const invalidEnd = commands.find(cmd => cmd.name === 'invalid-end-');
-      const tooLong = commands.find(cmd => cmd.name === longCommandName);
-      const valid = commands.find(cmd => cmd.name === 'valid-command');
+      const invalidStart = commands.find(
+        (cmd) => cmd.name === ".invalid-start",
+      );
+      const invalidEnd = commands.find((cmd) => cmd.name === "invalid-end-");
+      const tooLong = commands.find((cmd) => cmd.name === longCommandName);
+      const valid = commands.find((cmd) => cmd.name === "valid-command");
 
       expect(invalidStart?.isValid).toBe(false);
-      expect(invalidStart?.validationError).toContain('cannot start or end');
+      expect(invalidStart?.validationError).toContain("cannot start or end");
 
       expect(invalidEnd?.isValid).toBe(false);
-      expect(invalidEnd?.validationError).toContain('cannot start or end');
+      expect(invalidEnd?.validationError).toContain("cannot start or end");
 
       expect(tooLong?.isValid).toBe(false);
-      expect(tooLong?.validationError).toContain('too long');
+      expect(tooLong?.validationError).toContain("too long");
 
       expect(valid?.isValid).toBe(true);
     });
 
-    it('should sanitize command descriptions', async () => {
-      const { discoverClaudeCommands, clearCommandsCache } = await import('../commands.improved.js');
+    it("should sanitize command descriptions", async () => {
+      const { discoverClaudeCommands, clearCommandsCache } = await import(
+        "../commands.improved.js"
+      );
 
       clearCommandsCache();
 
-      mockReaddir.mockResolvedValue(['sanitize-test.md']);
+      mockReaddir.mockResolvedValue(["sanitize-test.md"]);
       mockReadFile.mockResolvedValue(`---
 description: "Command with <script>alert('xss')</script> and control chars \x00\x08"
 ---
@@ -171,21 +197,23 @@ description: "Command with <script>alert('xss')</script> and control chars \x00\
       const commands = await discoverClaudeCommands();
 
       expect(commands).toHaveLength(1);
-      expect(commands[0].description).not.toContain('<script>');
-      expect(commands[0].description).not.toContain('\x00');
-      expect(commands[0].description).not.toContain('\x08');
+      expect(commands[0].description).not.toContain("<script>");
+      expect(commands[0].description).not.toContain("\x00");
+      expect(commands[0].description).not.toContain("\x08");
       // Should have removed < and > characters and control chars
       expect(commands[0].description).toContain("alert('xss')");
-      expect(commands[0].description).not.toContain('<');
-      expect(commands[0].description).not.toContain('>');
+      expect(commands[0].description).not.toContain("<");
+      expect(commands[0].description).not.toContain(">");
     });
 
-    it('should handle malformed frontmatter gracefully', async () => {
-      const { discoverClaudeCommands, clearCommandsCache } = await import('../commands.improved.js');
+    it("should handle malformed frontmatter gracefully", async () => {
+      const { discoverClaudeCommands, clearCommandsCache } = await import(
+        "../commands.improved.js"
+      );
 
       clearCommandsCache();
 
-      mockReaddir.mockResolvedValue(['malformed.md']);
+      mockReaddir.mockResolvedValue(["malformed.md"]);
       mockReadFile.mockResolvedValue(`---
 invalid: yaml: syntax: {[}]
 description without colon
@@ -204,14 +232,16 @@ malformed structure
     });
   });
 
-  describe('Caching Functionality', () => {
-    it('should cache discovered commands', async () => {
-      const { discoverClaudeCommands, clearCommandsCache } = await import('../commands.improved.js');
+  describe("Caching Functionality", () => {
+    it("should cache discovered commands", async () => {
+      const { discoverClaudeCommands, clearCommandsCache } = await import(
+        "../commands.improved.js"
+      );
 
       clearCommandsCache();
 
-      mockReaddir.mockResolvedValue(['cached-command.md']);
-      mockReadFile.mockResolvedValue('# Cached Command');
+      mockReaddir.mockResolvedValue(["cached-command.md"]);
+      mockReadFile.mockResolvedValue("# Cached Command");
 
       // First call should read from filesystem
       const commands1 = await discoverClaudeCommands();
@@ -226,17 +256,19 @@ malformed structure
       expect(commands1).toEqual(commands2);
       expect(getLogger().debug).toHaveBeenCalledWith(
         expect.objectContaining({ cached: true }),
-        'Using cached Claude commands'
+        "Using cached Claude commands",
       );
     });
 
-    it('should clear cache when requested', async () => {
-      const { discoverClaudeCommands, clearCommandsCache } = await import('../commands.improved.js');
+    it("should clear cache when requested", async () => {
+      const { discoverClaudeCommands, clearCommandsCache } = await import(
+        "../commands.improved.js"
+      );
 
       clearCommandsCache();
 
-      mockReaddir.mockResolvedValue(['test-command.md']);
-      mockReadFile.mockResolvedValue('# Test Command');
+      mockReaddir.mockResolvedValue(["test-command.md"]);
+      mockReadFile.mockResolvedValue("# Test Command");
 
       // First discovery
       await discoverClaudeCommands();
@@ -250,12 +282,16 @@ malformed structure
       expect(mockReaddir).toHaveBeenCalledTimes(2);
     });
 
-    it('should cache empty results when no commands directory exists', async () => {
-      const { discoverClaudeCommands, clearCommandsCache } = await import('../commands.improved.js');
+    it("should cache empty results when no commands directory exists", async () => {
+      const { discoverClaudeCommands, clearCommandsCache } = await import(
+        "../commands.improved.js"
+      );
 
       clearCommandsCache();
 
-      mockReaddir.mockRejectedValue(new Error('ENOENT: no such file or directory'));
+      mockReaddir.mockRejectedValue(
+        new Error("ENOENT: no such file or directory"),
+      );
 
       // First call should attempt to read directory
       const commands1 = await discoverClaudeCommands();
@@ -269,93 +305,112 @@ malformed structure
     });
   });
 
-  describe('Filtered Command Access', () => {
-    it('should return only valid commands', async () => {
-      const { getValidClaudeCommands, clearCommandsCache } = await import('../commands.improved.js');
+  describe("Filtered Command Access", () => {
+    it("should return only valid commands", async () => {
+      const { getValidClaudeCommands, clearCommandsCache } = await import(
+        "../commands.improved.js"
+      );
 
       clearCommandsCache();
 
-      mockReaddir.mockResolvedValue(['valid.md', 'start.md', 'another-valid.md']);
+      mockReaddir.mockResolvedValue([
+        "valid.md",
+        "start.md",
+        "another-valid.md",
+      ]);
       mockReadFile
-        .mockResolvedValueOnce('# Valid Command')
-        .mockResolvedValueOnce('# Start Command (conflicts)')
-        .mockResolvedValueOnce('# Another Valid Command');
+        .mockResolvedValueOnce("# Valid Command")
+        .mockResolvedValueOnce("# Start Command (conflicts)")
+        .mockResolvedValueOnce("# Another Valid Command");
 
       const validCommands = await getValidClaudeCommands();
 
       expect(validCommands).toHaveLength(2);
-      expect(validCommands.map(cmd => cmd.name)).toEqual(['valid', 'another-valid']);
-      expect(validCommands.every(cmd => cmd.isValid)).toBe(true);
+      expect(validCommands.map((cmd) => cmd.name)).toEqual([
+        "valid",
+        "another-valid",
+      ]);
+      expect(validCommands.every((cmd) => cmd.isValid)).toBe(true);
     });
 
-    it('should get specific valid command by name', async () => {
-      const { getValidClaudeCommand, clearCommandsCache } = await import('../commands.improved.js');
+    it("should get specific valid command by name", async () => {
+      const { getValidClaudeCommand, clearCommandsCache } = await import(
+        "../commands.improved.js"
+      );
 
       clearCommandsCache();
 
-      mockReaddir.mockResolvedValue(['valid.md', 'start.md']);
+      mockReaddir.mockResolvedValue(["valid.md", "start.md"]);
       mockReadFile
-        .mockResolvedValueOnce('# Valid Command')
-        .mockResolvedValueOnce('# Start Command');
+        .mockResolvedValueOnce("# Valid Command")
+        .mockResolvedValueOnce("# Start Command");
 
-      const validCommand = await getValidClaudeCommand('valid');
-      const invalidCommand = await getValidClaudeCommand('start');
+      const validCommand = await getValidClaudeCommand("valid");
+      const invalidCommand = await getValidClaudeCommand("start");
 
-      expect(validCommand?.name).toBe('valid');
+      expect(validCommand?.name).toBe("valid");
       expect(validCommand?.isValid).toBe(true);
       expect(invalidCommand).toBeNull(); // Invalid command should return null
     });
 
-    it('should get validation errors for debugging', async () => {
-      const { getCommandValidationErrors, clearCommandsCache } = await import('../commands.improved.js');
+    it("should get validation errors for debugging", async () => {
+      const { getCommandValidationErrors, clearCommandsCache } = await import(
+        "../commands.improved.js"
+      );
 
       clearCommandsCache();
 
-      mockReaddir.mockResolvedValue(['start.md', 'help.md', 'invalid@name.md']);
+      mockReaddir.mockResolvedValue(["start.md", "help.md", "invalid@name.md"]);
       mockReadFile
-        .mockResolvedValue('# Command')
-        .mockResolvedValue('# Command')
-        .mockResolvedValue('# Command');
+        .mockResolvedValue("# Command")
+        .mockResolvedValue("# Command")
+        .mockResolvedValue("# Command");
 
       const errors = await getCommandValidationErrors();
 
       expect(errors).toHaveLength(3);
-      expect(errors.map(e => e.name)).toEqual(expect.arrayContaining(['start', 'help', 'invalid@name']));
-      expect(errors.every(e => e.error)).toBeTruthy();
+      expect(errors.map((e) => e.name)).toEqual(
+        expect.arrayContaining(["start", "help", "invalid@name"]),
+      );
+      expect(errors.every((e) => e.error)).toBeTruthy();
     });
   });
 
-  describe('Integration with Existing getClaudeCommand', () => {
-    it('should maintain backward compatibility with getClaudeCommand', async () => {
-      const { getClaudeCommand, clearCommandsCache } = await import('../commands.improved.js');
+  describe("Integration with Existing getClaudeCommand", () => {
+    it("should maintain backward compatibility with getClaudeCommand", async () => {
+      const { getClaudeCommand, clearCommandsCache } = await import(
+        "../commands.improved.js"
+      );
 
       clearCommandsCache();
 
-      mockReaddir.mockResolvedValue(['test.md', 'start.md']);
+      mockReaddir.mockResolvedValue(["test.md", "start.md"]);
       mockReadFile
-        .mockResolvedValueOnce('# Test Command')
-        .mockResolvedValueOnce('# Start Command');
+        .mockResolvedValueOnce("# Test Command")
+        .mockResolvedValueOnce("# Start Command");
 
-      const validCommand = await getClaudeCommand('test');
-      const invalidCommand = await getClaudeCommand('start');
+      const validCommand = await getClaudeCommand("test");
+      const invalidCommand = await getClaudeCommand("start");
 
       // Should return command objects regardless of validity
-      expect(validCommand?.name).toBe('test');
+      expect(validCommand?.name).toBe("test");
       expect(validCommand?.isValid).toBe(true);
 
-      expect(invalidCommand?.name).toBe('start');
+      expect(invalidCommand?.name).toBe("start");
       expect(invalidCommand?.isValid).toBe(false);
     });
 
-    it('should return null for non-existent commands', async () => {
-      const { getClaudeCommand, clearCommandsCache } = await import('../commands.improved.js');
+    it("should return null for non-existent commands", async () => {
+      const { getClaudeCommand, clearCommandsCache } = await import(
+        "../commands.improved.js"
+      );
 
       clearCommandsCache();
 
-      mockReaddir.mockResolvedValue(['existing.md']);
-      mockReadFile.mockResolvedValue('# Existing Command');
+      mockReaddir.mockResolvedValue(["existing.md"]);
+      mockReadFile.mockResolvedValue("# Existing Command");
 
-      const nonExistent = await getClaudeCommand('non-existent');
+      const nonExistent = await getClaudeCommand("non-existent");
 
       expect(nonExistent).toBeNull();
     });

--- a/src/claude/__tests__/commands.improved.test.ts
+++ b/src/claude/__tests__/commands.improved.test.ts
@@ -18,7 +18,7 @@ vi.mock("node:fs/promises", () => ({
 
 describe("Improved Claude Commands - Performance and Validation", () => {
   const testWorkingDir = "/test/working";
-  const testCommandsDir = join(testWorkingDir, ".claude", "commands");
+  const _testCommandsDir = join(testWorkingDir, ".claude", "commands");
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/claude/__tests__/commands.simple.test.ts
+++ b/src/claude/__tests__/commands.simple.test.ts
@@ -1,0 +1,360 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { join } from 'node:path';
+import { getWorkingDirectory } from '../../config.js';
+import { getLogger } from '../../logger.js';
+
+// Mock dependencies
+vi.mock('../../config.js');
+vi.mock('../../logger.js');
+
+// Mock fs operations at the top level
+const mockReaddir = vi.fn();
+const mockReadFile = vi.fn();
+
+vi.mock('node:fs/promises', () => ({
+  readdir: mockReaddir,
+  readFile: mockReadFile,
+}));
+
+describe('Claude Commands - Core Functionality', () => {
+  const testWorkingDir = '/test/working';
+  const testCommandsDir = join(testWorkingDir, '.claude', 'commands');
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Mock working directory
+    vi.mocked(getWorkingDirectory).mockReturnValue(testWorkingDir);
+
+    // Mock logger
+    vi.mocked(getLogger).mockReturnValue({
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as any);
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('Command Discovery', () => {
+    it('should discover commands with valid frontmatter', async () => {
+      // Import after mocks are set up
+      const { discoverClaudeCommands } = await import('../commands.js');
+
+      // Setup mock data
+      mockReaddir.mockResolvedValue(['test-command.md', 'another-command.md', 'not-markdown.txt']);
+
+      mockReadFile
+        .mockResolvedValueOnce(`---
+description: Test command for testing
+---
+
+# Test Command
+This is a test command.`)
+        .mockResolvedValueOnce(`---
+description: Another test command
+---
+
+# Another Command
+This is another test command.`);
+
+      const commands = await discoverClaudeCommands();
+
+      expect(commands).toHaveLength(2);
+      expect(commands[0]).toEqual({
+        name: 'test-command',
+        filePath: join(testCommandsDir, 'test-command.md'),
+        description: 'Test command for testing',
+        content: expect.stringContaining('# Test Command'),
+      });
+      expect(commands[1]).toEqual({
+        name: 'another-command',
+        filePath: join(testCommandsDir, 'another-command.md'),
+        description: 'Another test command',
+        content: expect.stringContaining('# Another Command'),
+      });
+    });
+
+    it('should handle commands without frontmatter', async () => {
+      const { discoverClaudeCommands } = await import('../commands.js');
+
+      mockReaddir.mockResolvedValue(['simple-command.md']);
+      mockReadFile.mockResolvedValue('# Simple Command\nThis command has no frontmatter.');
+
+      const commands = await discoverClaudeCommands();
+
+      expect(commands).toHaveLength(1);
+      expect(commands[0]).toEqual({
+        name: 'simple-command',
+        filePath: join(testCommandsDir, 'simple-command.md'),
+        description: undefined,
+        content: '# Simple Command\nThis command has no frontmatter.',
+      });
+    });
+
+    it('should ignore non-markdown files', async () => {
+      const { discoverClaudeCommands } = await import('../commands.js');
+
+      mockReaddir.mockResolvedValue([
+        'command.md',
+        'readme.txt',
+        'config.json',
+        'script.sh',
+        'another-command.md'
+      ]);
+
+      mockReadFile
+        .mockResolvedValueOnce('# Command 1')
+        .mockResolvedValueOnce('# Command 2');
+
+      const commands = await discoverClaudeCommands();
+
+      expect(commands).toHaveLength(2);
+      expect(mockReadFile).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle directory not found gracefully', async () => {
+      const { discoverClaudeCommands } = await import('../commands.js');
+
+      mockReaddir.mockRejectedValue(new Error('ENOENT: no such file or directory'));
+
+      const commands = await discoverClaudeCommands();
+
+      expect(commands).toHaveLength(0);
+      expect(getLogger().debug).toHaveBeenCalledWith(
+        expect.objectContaining({ commandsDir: testCommandsDir }),
+        'No Claude commands directory found'
+      );
+    });
+
+    it('should handle individual file read errors', async () => {
+      const { discoverClaudeCommands } = await import('../commands.js');
+
+      mockReaddir.mockResolvedValue(['working.md', 'broken.md', 'also-working.md']);
+
+      mockReadFile
+        .mockResolvedValueOnce('# Working Command 1')
+        .mockRejectedValueOnce(new Error('Permission denied'))
+        .mockResolvedValueOnce('# Working Command 2');
+
+      const commands = await discoverClaudeCommands();
+
+      expect(commands).toHaveLength(2);
+      expect(commands[0].name).toBe('working');
+      expect(commands[1].name).toBe('also-working');
+
+      expect(getLogger().warn).toHaveBeenCalledWith(
+        expect.objectContaining({ file: 'broken.md' }),
+        'Failed to read Claude command file'
+      );
+    });
+
+    it('should handle empty command files', async () => {
+      const { discoverClaudeCommands } = await import('../commands.js');
+
+      mockReaddir.mockResolvedValue(['empty.md']);
+      mockReadFile.mockResolvedValue('');
+
+      const commands = await discoverClaudeCommands();
+
+      expect(commands).toHaveLength(1);
+      expect(commands[0]).toEqual({
+        name: 'empty',
+        filePath: join(testCommandsDir, 'empty.md'),
+        description: undefined,
+        content: '',
+      });
+    });
+  });
+
+  describe('Frontmatter Parsing', () => {
+    it('should parse simple description field', async () => {
+      const { discoverClaudeCommands } = await import('../commands.js');
+
+      mockReaddir.mockResolvedValue(['test.md']);
+      mockReadFile.mockResolvedValue(`---
+description: Simple description
+---
+Content`);
+
+      const commands = await discoverClaudeCommands();
+      expect(commands[0].description).toBe('Simple description');
+    });
+
+    it('should handle quoted descriptions', async () => {
+      const { discoverClaudeCommands } = await import('../commands.js');
+
+      mockReaddir.mockResolvedValue(['test.md']);
+      mockReadFile.mockResolvedValue(`---
+description: "Quoted description with special chars: !@#$%"
+---
+Content`);
+
+      const commands = await discoverClaudeCommands();
+      expect(commands[0].description).toBe('"Quoted description with special chars: !@#$%"');
+    });
+
+    it('should ignore non-description frontmatter fields', async () => {
+      const { discoverClaudeCommands } = await import('../commands.js');
+
+      mockReaddir.mockResolvedValue(['test.md']);
+      mockReadFile.mockResolvedValue(`---
+title: Test Command
+author: Developer
+description: Only this matters
+version: 1.0.0
+---
+Content`);
+
+      const commands = await discoverClaudeCommands();
+      expect(commands[0].description).toBe('Only this matters');
+    });
+
+    it('should handle missing description field', async () => {
+      const { discoverClaudeCommands } = await import('../commands.js');
+
+      mockReaddir.mockResolvedValue(['test.md']);
+      mockReadFile.mockResolvedValue(`---
+title: Test Command
+author: Developer
+---
+Content`);
+
+      const commands = await discoverClaudeCommands();
+      expect(commands[0].description).toBeUndefined();
+    });
+  });
+
+  describe('getClaudeCommand Function', () => {
+    it('should return specific command by name', async () => {
+      const { getClaudeCommand } = await import('../commands.js');
+
+      mockReaddir.mockResolvedValue(['first.md', 'second.md', 'third.md']);
+
+      mockReadFile
+        .mockResolvedValueOnce('# First Command')
+        .mockResolvedValueOnce(`---
+description: This is the second command
+---
+# Second Command`)
+        .mockResolvedValueOnce('# Third Command');
+
+      const command = await getClaudeCommand('second');
+
+      expect(command).toEqual({
+        name: 'second',
+        filePath: join(testCommandsDir, 'second.md'),
+        description: 'This is the second command',
+        content: expect.stringContaining('# Second Command'),
+      });
+    });
+
+    it('should return null for non-existent command', async () => {
+      const { getClaudeCommand } = await import('../commands.js');
+
+      mockReaddir.mockResolvedValue(['first.md', 'second.md']);
+      mockReadFile
+        .mockResolvedValueOnce('# First Command')
+        .mockResolvedValueOnce('# Second Command');
+
+      const command = await getClaudeCommand('nonexistent');
+
+      expect(command).toBeNull();
+    });
+
+    it('should handle empty commands directory', async () => {
+      const { getClaudeCommand } = await import('../commands.js');
+
+      mockReaddir.mockResolvedValue([]);
+
+      const command = await getClaudeCommand('any-command');
+
+      expect(command).toBeNull();
+    });
+  });
+
+  describe('Performance and Validation Tests', () => {
+    it('should handle special characters in command names', async () => {
+      const { discoverClaudeCommands } = await import('../commands.js');
+
+      mockReaddir.mockResolvedValue([
+        'special-chars_123.md',
+        'dots.in.name.md',
+        'numbers-123.md'
+      ]);
+
+      mockReadFile
+        .mockResolvedValue('# Command 1')
+        .mockResolvedValue('# Command 2')
+        .mockResolvedValue('# Command 3');
+
+      const commands = await discoverClaudeCommands();
+
+      expect(commands).toHaveLength(3);
+      expect(commands[0].name).toBe('special-chars_123');
+      expect(commands[1].name).toBe('dots.in.name');
+      expect(commands[2].name).toBe('numbers-123');
+    });
+
+    it('should handle very long command names', async () => {
+      const { discoverClaudeCommands } = await import('../commands.js');
+
+      const longName = 'very-long-command-name-that-exceeds-normal-length-expectations-and-might-cause-issues';
+      mockReaddir.mockResolvedValue([`${longName}.md`]);
+      mockReadFile.mockResolvedValue('# Long Command');
+
+      const commands = await discoverClaudeCommands();
+
+      expect(commands).toHaveLength(1);
+      expect(commands[0].name).toBe(longName);
+    });
+
+    it('should detect potential command conflicts', async () => {
+      const { discoverClaudeCommands } = await import('../commands.js');
+
+      // Test for commands that might conflict with built-in commands
+      const conflictingNames = ['start', 'help', 'stop', 'clear', 'settings'];
+
+      mockReaddir.mockResolvedValue(conflictingNames.map(name => `${name}.md`));
+
+      // Mock file reads for each command
+      for (let i = 0; i < conflictingNames.length; i++) {
+        mockReadFile.mockResolvedValueOnce(`# ${conflictingNames[i]} command`);
+      }
+
+      const commands = await discoverClaudeCommands();
+
+      expect(commands).toHaveLength(conflictingNames.length);
+
+      // Note: This test identifies the issue but doesn't fix it yet
+      // The actual validation will be added in the performance fixes
+      const builtInCommands = ['start', 'help', 'stop', 'clear', 'settings'];
+      const discoveredNames = commands.map(cmd => cmd.name);
+      const conflicts = discoveredNames.filter(name => builtInCommands.includes(name));
+
+      // This shows we can detect conflicts (we'll add validation later)
+      expect(conflicts).toEqual(expect.arrayContaining(['start', 'help', 'stop', 'clear', 'settings']));
+    });
+
+    it('should handle malformed frontmatter without crashing', async () => {
+      const { discoverClaudeCommands } = await import('../commands.js');
+
+      mockReaddir.mockResolvedValue(['malformed.md']);
+      mockReadFile.mockResolvedValue(`---
+invalid yaml syntax {[
+no proper structure
+description without colon
+---
+# Malformed Command`);
+
+      const commands = await discoverClaudeCommands();
+
+      expect(commands).toHaveLength(1);
+      expect(commands[0].description).toBeUndefined();
+      expect(commands[0].content).toContain('# Malformed Command');
+    });
+  });
+});

--- a/src/claude/__tests__/commands.simple.test.ts
+++ b/src/claude/__tests__/commands.simple.test.ts
@@ -1,27 +1,41 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { join } from 'node:path';
-import { getWorkingDirectory } from '../../config.js';
-import { getLogger } from '../../logger.js';
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getWorkingDirectory } from "../../config.js";
+import { getLogger } from "../../logger.js";
+import { clearCommandCache } from "../commands.js";
 
 // Mock dependencies
-vi.mock('../../config.js');
-vi.mock('../../logger.js');
+vi.mock("../../config.js");
+vi.mock("../../logger.js");
 
-// Mock fs operations at the top level
-const mockReaddir = vi.fn();
-const mockReadFile = vi.fn();
+// Mock fs operations with factory function
+vi.mock("node:fs/promises", () => {
+  const mockReaddir = vi.fn();
+  const mockReadFile = vi.fn();
 
-vi.mock('node:fs/promises', () => ({
-  readdir: mockReaddir,
-  readFile: mockReadFile,
-}));
+  // Export the mocks to be accessible in tests
+  (global as any).__mockReaddir = mockReaddir;
+  (global as any).__mockReadFile = mockReadFile;
 
-describe('Claude Commands - Core Functionality', () => {
-  const testWorkingDir = '/test/working';
-  const testCommandsDir = join(testWorkingDir, '.claude', 'commands');
+  return {
+    readdir: mockReaddir,
+    readFile: mockReadFile,
+  };
+});
+
+// Get references to the mocks
+const mockReaddir = (global as any).__mockReaddir;
+const mockReadFile = (global as any).__mockReadFile;
+
+describe("Claude Commands - Core Functionality", () => {
+  const testWorkingDir = "/test/working";
+  const testCommandsDir = join(testWorkingDir, ".claude", "commands");
 
   beforeEach(() => {
     vi.clearAllMocks();
+
+    // Clear command cache to ensure fresh state for each test
+    clearCommandCache();
 
     // Mock working directory
     vi.mocked(getWorkingDirectory).mockReturnValue(testWorkingDir);
@@ -39,13 +53,17 @@ describe('Claude Commands - Core Functionality', () => {
     vi.resetAllMocks();
   });
 
-  describe('Command Discovery', () => {
-    it('should discover commands with valid frontmatter', async () => {
+  describe("Command Discovery", () => {
+    it("should discover commands with valid frontmatter", async () => {
       // Import after mocks are set up
-      const { discoverClaudeCommands } = await import('../commands.js');
+      const { discoverClaudeCommands } = await import("../commands.js");
 
       // Setup mock data
-      mockReaddir.mockResolvedValue(['test-command.md', 'another-command.md', 'not-markdown.txt']);
+      mockReaddir.mockResolvedValue([
+        "test-command.md",
+        "another-command.md",
+        "not-markdown.txt",
+      ]);
 
       mockReadFile
         .mockResolvedValueOnce(`---
@@ -65,50 +83,52 @@ This is another test command.`);
 
       expect(commands).toHaveLength(2);
       expect(commands[0]).toEqual({
-        name: 'test-command',
-        filePath: join(testCommandsDir, 'test-command.md'),
-        description: 'Test command for testing',
-        content: expect.stringContaining('# Test Command'),
+        name: "test-command",
+        filePath: join(testCommandsDir, "test-command.md"),
+        description: "Test command for testing",
+        content: expect.stringContaining("# Test Command"),
       });
       expect(commands[1]).toEqual({
-        name: 'another-command',
-        filePath: join(testCommandsDir, 'another-command.md'),
-        description: 'Another test command',
-        content: expect.stringContaining('# Another Command'),
+        name: "another-command",
+        filePath: join(testCommandsDir, "another-command.md"),
+        description: "Another test command",
+        content: expect.stringContaining("# Another Command"),
       });
     });
 
-    it('should handle commands without frontmatter', async () => {
-      const { discoverClaudeCommands } = await import('../commands.js');
+    it("should handle commands without frontmatter", async () => {
+      const { discoverClaudeCommands } = await import("../commands.js");
 
-      mockReaddir.mockResolvedValue(['simple-command.md']);
-      mockReadFile.mockResolvedValue('# Simple Command\nThis command has no frontmatter.');
+      mockReaddir.mockResolvedValue(["simple-command.md"]);
+      mockReadFile.mockResolvedValue(
+        "# Simple Command\nThis command has no frontmatter.",
+      );
 
       const commands = await discoverClaudeCommands();
 
       expect(commands).toHaveLength(1);
       expect(commands[0]).toEqual({
-        name: 'simple-command',
-        filePath: join(testCommandsDir, 'simple-command.md'),
+        name: "simple-command",
+        filePath: join(testCommandsDir, "simple-command.md"),
         description: undefined,
-        content: '# Simple Command\nThis command has no frontmatter.',
+        content: "# Simple Command\nThis command has no frontmatter.",
       });
     });
 
-    it('should ignore non-markdown files', async () => {
-      const { discoverClaudeCommands } = await import('../commands.js');
+    it("should ignore non-markdown files", async () => {
+      const { discoverClaudeCommands } = await import("../commands.js");
 
       mockReaddir.mockResolvedValue([
-        'command.md',
-        'readme.txt',
-        'config.json',
-        'script.sh',
-        'another-command.md'
+        "command.md",
+        "readme.txt",
+        "config.json",
+        "script.sh",
+        "another-command.md",
       ]);
 
       mockReadFile
-        .mockResolvedValueOnce('# Command 1')
-        .mockResolvedValueOnce('# Command 2');
+        .mockResolvedValueOnce("# Command 1")
+        .mockResolvedValueOnce("# Command 2");
 
       const commands = await discoverClaudeCommands();
 
@@ -116,91 +136,99 @@ This is another test command.`);
       expect(mockReadFile).toHaveBeenCalledTimes(2);
     });
 
-    it('should handle directory not found gracefully', async () => {
-      const { discoverClaudeCommands } = await import('../commands.js');
+    it("should handle directory not found gracefully", async () => {
+      const { discoverClaudeCommands } = await import("../commands.js");
 
-      mockReaddir.mockRejectedValue(new Error('ENOENT: no such file or directory'));
+      mockReaddir.mockRejectedValue(
+        new Error("ENOENT: no such file or directory"),
+      );
 
       const commands = await discoverClaudeCommands();
 
       expect(commands).toHaveLength(0);
       expect(getLogger().debug).toHaveBeenCalledWith(
         expect.objectContaining({ commandsDir: testCommandsDir }),
-        'No Claude commands directory found'
+        "No Claude commands directory found",
       );
     });
 
-    it('should handle individual file read errors', async () => {
-      const { discoverClaudeCommands } = await import('../commands.js');
+    it("should handle individual file read errors", async () => {
+      const { discoverClaudeCommands } = await import("../commands.js");
 
-      mockReaddir.mockResolvedValue(['working.md', 'broken.md', 'also-working.md']);
+      mockReaddir.mockResolvedValue([
+        "working.md",
+        "broken.md",
+        "also-working.md",
+      ]);
 
       mockReadFile
-        .mockResolvedValueOnce('# Working Command 1')
-        .mockRejectedValueOnce(new Error('Permission denied'))
-        .mockResolvedValueOnce('# Working Command 2');
+        .mockResolvedValueOnce("# Working Command 1")
+        .mockRejectedValueOnce(new Error("Permission denied"))
+        .mockResolvedValueOnce("# Working Command 2");
 
       const commands = await discoverClaudeCommands();
 
       expect(commands).toHaveLength(2);
-      expect(commands[0].name).toBe('working');
-      expect(commands[1].name).toBe('also-working');
+      expect(commands[0].name).toBe("working");
+      expect(commands[1].name).toBe("also-working");
 
       expect(getLogger().warn).toHaveBeenCalledWith(
-        expect.objectContaining({ file: 'broken.md' }),
-        'Failed to read Claude command file'
+        expect.objectContaining({ file: "broken.md" }),
+        "Failed to read Claude command file",
       );
     });
 
-    it('should handle empty command files', async () => {
-      const { discoverClaudeCommands } = await import('../commands.js');
+    it("should handle empty command files", async () => {
+      const { discoverClaudeCommands } = await import("../commands.js");
 
-      mockReaddir.mockResolvedValue(['empty.md']);
-      mockReadFile.mockResolvedValue('');
+      mockReaddir.mockResolvedValue(["empty.md"]);
+      mockReadFile.mockResolvedValue("");
 
       const commands = await discoverClaudeCommands();
 
       expect(commands).toHaveLength(1);
       expect(commands[0]).toEqual({
-        name: 'empty',
-        filePath: join(testCommandsDir, 'empty.md'),
+        name: "empty",
+        filePath: join(testCommandsDir, "empty.md"),
         description: undefined,
-        content: '',
+        content: "",
       });
     });
   });
 
-  describe('Frontmatter Parsing', () => {
-    it('should parse simple description field', async () => {
-      const { discoverClaudeCommands } = await import('../commands.js');
+  describe("Frontmatter Parsing", () => {
+    it("should parse simple description field", async () => {
+      const { discoverClaudeCommands } = await import("../commands.js");
 
-      mockReaddir.mockResolvedValue(['test.md']);
+      mockReaddir.mockResolvedValue(["test.md"]);
       mockReadFile.mockResolvedValue(`---
 description: Simple description
 ---
 Content`);
 
       const commands = await discoverClaudeCommands();
-      expect(commands[0].description).toBe('Simple description');
+      expect(commands[0].description).toBe("Simple description");
     });
 
-    it('should handle quoted descriptions', async () => {
-      const { discoverClaudeCommands } = await import('../commands.js');
+    it("should handle quoted descriptions", async () => {
+      const { discoverClaudeCommands } = await import("../commands.js");
 
-      mockReaddir.mockResolvedValue(['test.md']);
+      mockReaddir.mockResolvedValue(["test.md"]);
       mockReadFile.mockResolvedValue(`---
 description: "Quoted description with special chars: !@#$%"
 ---
 Content`);
 
       const commands = await discoverClaudeCommands();
-      expect(commands[0].description).toBe('"Quoted description with special chars: !@#$%"');
+      expect(commands[0].description).toBe(
+        'Quoted description with special chars: !@#$%',
+      );
     });
 
-    it('should ignore non-description frontmatter fields', async () => {
-      const { discoverClaudeCommands } = await import('../commands.js');
+    it("should ignore non-description frontmatter fields", async () => {
+      const { discoverClaudeCommands } = await import("../commands.js");
 
-      mockReaddir.mockResolvedValue(['test.md']);
+      mockReaddir.mockResolvedValue(["test.md"]);
       mockReadFile.mockResolvedValue(`---
 title: Test Command
 author: Developer
@@ -210,13 +238,13 @@ version: 1.0.0
 Content`);
 
       const commands = await discoverClaudeCommands();
-      expect(commands[0].description).toBe('Only this matters');
+      expect(commands[0].description).toBe("Only this matters");
     });
 
-    it('should handle missing description field', async () => {
-      const { discoverClaudeCommands } = await import('../commands.js');
+    it("should handle missing description field", async () => {
+      const { discoverClaudeCommands } = await import("../commands.js");
 
-      mockReaddir.mockResolvedValue(['test.md']);
+      mockReaddir.mockResolvedValue(["test.md"]);
       mockReadFile.mockResolvedValue(`---
 title: Test Command
 author: Developer
@@ -228,83 +256,84 @@ Content`);
     });
   });
 
-  describe('getClaudeCommand Function', () => {
-    it('should return specific command by name', async () => {
-      const { getClaudeCommand } = await import('../commands.js');
+  describe("getClaudeCommand Function", () => {
+    it("should return specific command by name", async () => {
+      const { getClaudeCommand } = await import("../commands.js");
 
-      mockReaddir.mockResolvedValue(['first.md', 'second.md', 'third.md']);
+      mockReaddir.mockResolvedValue(["first.md", "second.md", "third.md"]);
 
       mockReadFile
-        .mockResolvedValueOnce('# First Command')
+        .mockResolvedValueOnce("# First Command")
         .mockResolvedValueOnce(`---
 description: This is the second command
 ---
 # Second Command`)
-        .mockResolvedValueOnce('# Third Command');
+        .mockResolvedValueOnce("# Third Command");
 
-      const command = await getClaudeCommand('second');
+      const command = await getClaudeCommand("second");
 
       expect(command).toEqual({
-        name: 'second',
-        filePath: join(testCommandsDir, 'second.md'),
-        description: 'This is the second command',
-        content: expect.stringContaining('# Second Command'),
+        name: "second",
+        filePath: join(testCommandsDir, "second.md"),
+        description: "This is the second command",
+        content: expect.stringContaining("# Second Command"),
       });
     });
 
-    it('should return null for non-existent command', async () => {
-      const { getClaudeCommand } = await import('../commands.js');
+    it("should return null for non-existent command", async () => {
+      const { getClaudeCommand } = await import("../commands.js");
 
-      mockReaddir.mockResolvedValue(['first.md', 'second.md']);
+      mockReaddir.mockResolvedValue(["first.md", "second.md"]);
       mockReadFile
-        .mockResolvedValueOnce('# First Command')
-        .mockResolvedValueOnce('# Second Command');
+        .mockResolvedValueOnce("# First Command")
+        .mockResolvedValueOnce("# Second Command");
 
-      const command = await getClaudeCommand('nonexistent');
+      const command = await getClaudeCommand("nonexistent");
 
       expect(command).toBeNull();
     });
 
-    it('should handle empty commands directory', async () => {
-      const { getClaudeCommand } = await import('../commands.js');
+    it("should handle empty commands directory", async () => {
+      const { getClaudeCommand } = await import("../commands.js");
 
       mockReaddir.mockResolvedValue([]);
 
-      const command = await getClaudeCommand('any-command');
+      const command = await getClaudeCommand("any-command");
 
       expect(command).toBeNull();
     });
   });
 
-  describe('Performance and Validation Tests', () => {
-    it('should handle special characters in command names', async () => {
-      const { discoverClaudeCommands } = await import('../commands.js');
+  describe("Performance and Validation Tests", () => {
+    it("should handle special characters in command names", async () => {
+      const { discoverClaudeCommands } = await import("../commands.js");
 
       mockReaddir.mockResolvedValue([
-        'special-chars_123.md',
-        'dots.in.name.md',
-        'numbers-123.md'
+        "special-chars_123.md",
+        "dots.in.name.md",
+        "numbers-123.md",
       ]);
 
       mockReadFile
-        .mockResolvedValue('# Command 1')
-        .mockResolvedValue('# Command 2')
-        .mockResolvedValue('# Command 3');
+        .mockResolvedValue("# Command 1")
+        .mockResolvedValue("# Command 2")
+        .mockResolvedValue("# Command 3");
 
       const commands = await discoverClaudeCommands();
 
       expect(commands).toHaveLength(3);
-      expect(commands[0].name).toBe('special-chars_123');
-      expect(commands[1].name).toBe('dots.in.name');
-      expect(commands[2].name).toBe('numbers-123');
+      expect(commands[0].name).toBe("special-chars_123");
+      expect(commands[1].name).toBe("dots.in.name");
+      expect(commands[2].name).toBe("numbers-123");
     });
 
-    it('should handle very long command names', async () => {
-      const { discoverClaudeCommands } = await import('../commands.js');
+    it("should handle very long command names", async () => {
+      const { discoverClaudeCommands } = await import("../commands.js");
 
-      const longName = 'very-long-command-name-that-exceeds-normal-length-expectations-and-might-cause-issues';
+      const longName =
+        "very-long-command-name-that-exceeds-normal-length-expectations-and-might-cause-issues";
       mockReaddir.mockResolvedValue([`${longName}.md`]);
-      mockReadFile.mockResolvedValue('# Long Command');
+      mockReadFile.mockResolvedValue("# Long Command");
 
       const commands = await discoverClaudeCommands();
 
@@ -312,13 +341,15 @@ description: This is the second command
       expect(commands[0].name).toBe(longName);
     });
 
-    it('should detect potential command conflicts', async () => {
-      const { discoverClaudeCommands } = await import('../commands.js');
+    it("should detect potential command conflicts", async () => {
+      const { discoverClaudeCommands } = await import("../commands.js");
 
       // Test for commands that might conflict with built-in commands
-      const conflictingNames = ['start', 'help', 'stop', 'clear', 'settings'];
+      const conflictingNames = ["start", "help", "stop", "clear", "settings"];
 
-      mockReaddir.mockResolvedValue(conflictingNames.map(name => `${name}.md`));
+      mockReaddir.mockResolvedValue(
+        conflictingNames.map((name) => `${name}.md`),
+      );
 
       // Mock file reads for each command
       for (let i = 0; i < conflictingNames.length; i++) {
@@ -327,22 +358,28 @@ description: This is the second command
 
       const commands = await discoverClaudeCommands();
 
-      expect(commands).toHaveLength(conflictingNames.length);
+      // Only non-reserved commands should be discovered
+      // Reserved: ["start", "help", "clear", "dynamic"]
+      // From conflictingNames: ["start", "help", "stop", "clear", "settings"]
+      // Expected to pass: ["stop", "settings"] = 2 commands
+      expect(commands).toHaveLength(2);
 
-      // Note: This test identifies the issue but doesn't fix it yet
-      // The actual validation will be added in the performance fixes
-      const builtInCommands = ['start', 'help', 'stop', 'clear', 'settings'];
-      const discoveredNames = commands.map(cmd => cmd.name);
-      const conflicts = discoveredNames.filter(name => builtInCommands.includes(name));
+      // Verify that reserved commands were filtered out and non-reserved ones were kept
+      const discoveredNames = commands.map((cmd) => cmd.name);
+      expect(discoveredNames).toEqual(
+        expect.arrayContaining(["stop", "settings"]),
+      );
 
-      // This shows we can detect conflicts (we'll add validation later)
-      expect(conflicts).toEqual(expect.arrayContaining(['start', 'help', 'stop', 'clear', 'settings']));
+      // Verify reserved commands were not included
+      expect(discoveredNames).not.toContain("start");
+      expect(discoveredNames).not.toContain("help");
+      expect(discoveredNames).not.toContain("clear");
     });
 
-    it('should handle malformed frontmatter without crashing', async () => {
-      const { discoverClaudeCommands } = await import('../commands.js');
+    it("should handle malformed frontmatter without crashing", async () => {
+      const { discoverClaudeCommands } = await import("../commands.js");
 
-      mockReaddir.mockResolvedValue(['malformed.md']);
+      mockReaddir.mockResolvedValue(["malformed.md"]);
       mockReadFile.mockResolvedValue(`---
 invalid yaml syntax {[
 no proper structure
@@ -354,7 +391,7 @@ description without colon
 
       expect(commands).toHaveLength(1);
       expect(commands[0].description).toBeUndefined();
-      expect(commands[0].content).toContain('# Malformed Command');
+      expect(commands[0].content).toContain("# Malformed Command");
     });
   });
 });

--- a/src/claude/__tests__/commands.simple.test.ts
+++ b/src/claude/__tests__/commands.simple.test.ts
@@ -221,7 +221,7 @@ Content`);
 
       const commands = await discoverClaudeCommands();
       expect(commands[0].description).toBe(
-        'Quoted description with special chars: !@#$%',
+        "Quoted description with special chars: !@#$%",
       );
     });
 

--- a/src/claude/__tests__/commands.simple.test.ts
+++ b/src/claude/__tests__/commands.simple.test.ts
@@ -14,8 +14,8 @@ vi.mock("node:fs/promises", () => {
   const mockReadFile = vi.fn();
 
   // Export the mocks to be accessible in tests
-  (global as any).__mockReaddir = mockReaddir;
-  (global as any).__mockReadFile = mockReadFile;
+  (global as unknown as Record<string, unknown>).__mockReaddir = mockReaddir;
+  (global as unknown as Record<string, unknown>).__mockReadFile = mockReadFile;
 
   return {
     readdir: mockReaddir,
@@ -24,8 +24,8 @@ vi.mock("node:fs/promises", () => {
 });
 
 // Get references to the mocks
-const mockReaddir = (global as any).__mockReaddir;
-const mockReadFile = (global as any).__mockReadFile;
+const mockReaddir = (global as any).__mockReaddir as ReturnType<typeof vi.fn>;
+const mockReadFile = (global as any).__mockReadFile as ReturnType<typeof vi.fn>;
 
 describe("Claude Commands - Core Functionality", () => {
   const testWorkingDir = "/test/working";
@@ -46,7 +46,7 @@ describe("Claude Commands - Core Functionality", () => {
       debug: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
-    } as any);
+    } as unknown as ReturnType<typeof getLogger>);
   });
 
   afterEach(() => {

--- a/src/claude/__tests__/executor.test.ts
+++ b/src/claude/__tests__/executor.test.ts
@@ -27,9 +27,13 @@ describe("executeClaudeQuery - Timestamp Functionality", () => {
 
     // Mock config
     vi.mocked(getConfig).mockReturnValue({
+      telegram: { botToken: "test-token" },
+      access: { allowedUserIds: [] },
       claude: { command: "claude-test" },
       dataDir: "/test/data",
-    } as any);
+      rateLimit: { max: 100, windowMs: 60000 },
+      logging: { level: "info" },
+    });
 
     // Mock working directory
     vi.mocked(getWorkingDirectory).mockReturnValue("/test/cwd");
@@ -39,7 +43,7 @@ describe("executeClaudeQuery - Timestamp Functionality", () => {
       info: vi.fn(),
       debug: vi.fn(),
       error: vi.fn(),
-    } as any);
+    } as unknown as ReturnType<typeof getLogger>);
   });
 
   afterEach(() => {

--- a/src/claude/__tests__/executor.test.ts
+++ b/src/claude/__tests__/executor.test.ts
@@ -1,13 +1,13 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { type ChildProcess } from 'node:child_process';
-import { executeClaudeQuery } from '../executor.js';
-import { getConfig, getWorkingDirectory } from '../../config.js';
-import { getLogger } from '../../logger.js';
+import type { ChildProcess } from "node:child_process";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getConfig, getWorkingDirectory } from "../../config.js";
+import { getLogger } from "../../logger.js";
+import { executeClaudeQuery } from "../executor.js";
 
 // Mock dependencies
-vi.mock('node:child_process');
-vi.mock('../../config.js');
-vi.mock('../../logger.js');
+vi.mock("node:child_process");
+vi.mock("../../config.js");
+vi.mock("../../logger.js");
 
 // Create a mock child process
 const createMockChildProcess = () => {
@@ -15,24 +15,24 @@ const createMockChildProcess = () => {
     stdout: { on: vi.fn() },
     stderr: { on: vi.fn() },
     on: vi.fn(),
-    kill: vi.fn()
+    kill: vi.fn(),
   } as unknown as ChildProcess;
 
   return mockProcess;
 };
 
-describe('executeClaudeQuery - Timestamp Functionality', () => {
+describe("executeClaudeQuery - Timestamp Functionality", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
     // Mock config
     vi.mocked(getConfig).mockReturnValue({
-      claude: { command: 'claude-test' },
-      dataDir: '/test/data',
+      claude: { command: "claude-test" },
+      dataDir: "/test/data",
     } as any);
 
     // Mock working directory
-    vi.mocked(getWorkingDirectory).mockReturnValue('/test/cwd');
+    vi.mocked(getWorkingDirectory).mockReturnValue("/test/cwd");
 
     // Mock logger
     vi.mocked(getLogger).mockReturnValue({
@@ -46,150 +46,150 @@ describe('executeClaudeQuery - Timestamp Functionality', () => {
     vi.resetAllMocks();
   });
 
-  describe('System Context Building', () => {
-    it('should include timestamp in system context when messageTimestamp is provided', async () => {
-      const { spawn } = await import('node:child_process');
+  describe("System Context Building", () => {
+    it("should include timestamp in system context when messageTimestamp is provided", async () => {
+      const { spawn } = await import("node:child_process");
       const mockProcess = createMockChildProcess();
       vi.mocked(spawn).mockReturnValue(mockProcess);
 
       // Setup process to return successful result
       mockProcess.on = vi.fn((event, callback) => {
-        if (event === 'close') {
+        if (event === "close") {
           setTimeout(() => callback(0), 0);
         }
         return mockProcess;
       });
 
       const testTimestamp = 1709520000; // Unix timestamp in seconds
-      const expectedIsoString = '2024-03-04T02:40:00.000Z';
+      const expectedIsoString = "2024-03-04T02:40:00.000Z";
 
       executeClaudeQuery({
-        prompt: 'Test prompt',
-        userDir: '/test/user',
+        prompt: "Test prompt",
+        userDir: "/test/user",
         messageTimestamp: testTimestamp,
       });
 
       // Wait for spawn to be called
-      await new Promise(resolve => setTimeout(resolve, 1));
+      await new Promise((resolve) => setTimeout(resolve, 1));
 
       // Check that spawn was called with correct arguments
       expect(spawn).toHaveBeenCalledWith(
-        'claude-test',
+        "claude-test",
         expect.arrayContaining([
-          '-p',
+          "-p",
           `Test prompt\n\n[System: Message timestamp: ${expectedIsoString} (${testTimestamp})]`,
-          '--output-format',
-          'stream-json',
-          '--verbose'
+          "--output-format",
+          "stream-json",
+          "--verbose",
         ]),
-        expect.any(Object)
+        expect.any(Object),
       );
     });
 
-    it('should include both downloads path and timestamp when both are provided', async () => {
-      const { spawn } = await import('node:child_process');
+    it("should include both downloads path and timestamp when both are provided", async () => {
+      const { spawn } = await import("node:child_process");
       const mockProcess = createMockChildProcess();
       vi.mocked(spawn).mockReturnValue(mockProcess);
 
       mockProcess.on = vi.fn((event, callback) => {
-        if (event === 'close') {
+        if (event === "close") {
           setTimeout(() => callback(0), 0);
         }
         return mockProcess;
       });
 
       const testTimestamp = 1709520000;
-      const expectedIsoString = '2024-03-04T02:40:00.000Z';
-      const downloadsPath = '/test/downloads';
+      const expectedIsoString = "2024-03-04T02:40:00.000Z";
+      const downloadsPath = "/test/downloads";
 
       executeClaudeQuery({
-        prompt: 'Test prompt',
-        userDir: '/test/user',
+        prompt: "Test prompt",
+        userDir: "/test/user",
         downloadsPath,
         messageTimestamp: testTimestamp,
       });
 
-      await new Promise(resolve => setTimeout(resolve, 1));
+      await new Promise((resolve) => setTimeout(resolve, 1));
 
       expect(spawn).toHaveBeenCalledWith(
-        'claude-test',
+        "claude-test",
         expect.arrayContaining([
-          '-p',
+          "-p",
           `Test prompt\n\n[System: To send files to the user, write them to: ${downloadsPath} | Message timestamp: ${expectedIsoString} (${testTimestamp})]`,
         ]),
-        expect.any(Object)
+        expect.any(Object),
       );
     });
 
-    it('should not include timestamp in system context when messageTimestamp is undefined', async () => {
-      const { spawn } = await import('node:child_process');
+    it("should not include timestamp in system context when messageTimestamp is undefined", async () => {
+      const { spawn } = await import("node:child_process");
       const mockProcess = createMockChildProcess();
       vi.mocked(spawn).mockReturnValue(mockProcess);
 
       mockProcess.on = vi.fn((event, callback) => {
-        if (event === 'close') {
+        if (event === "close") {
           setTimeout(() => callback(0), 0);
         }
         return mockProcess;
       });
 
       executeClaudeQuery({
-        prompt: 'Test prompt',
-        userDir: '/test/user',
+        prompt: "Test prompt",
+        userDir: "/test/user",
         // messageTimestamp is undefined
       });
 
-      await new Promise(resolve => setTimeout(resolve, 1));
+      await new Promise((resolve) => setTimeout(resolve, 1));
 
       expect(spawn).toHaveBeenCalledWith(
-        'claude-test',
+        "claude-test",
         expect.arrayContaining([
-          '-p',
-          'Test prompt', // No system context appended
+          "-p",
+          "Test prompt", // No system context appended
         ]),
-        expect.any(Object)
+        expect.any(Object),
       );
     });
 
-    it('should not include timestamp when messageTimestamp is 0', async () => {
-      const { spawn } = await import('node:child_process');
+    it("should not include timestamp when messageTimestamp is 0", async () => {
+      const { spawn } = await import("node:child_process");
       const mockProcess = createMockChildProcess();
       vi.mocked(spawn).mockReturnValue(mockProcess);
 
       mockProcess.on = vi.fn((event, callback) => {
-        if (event === 'close') {
+        if (event === "close") {
           setTimeout(() => callback(0), 0);
         }
         return mockProcess;
       });
 
       executeClaudeQuery({
-        prompt: 'Test prompt',
-        userDir: '/test/user',
+        prompt: "Test prompt",
+        userDir: "/test/user",
         messageTimestamp: 0, // Falsy value
       });
 
-      await new Promise(resolve => setTimeout(resolve, 1));
+      await new Promise((resolve) => setTimeout(resolve, 1));
 
       expect(spawn).toHaveBeenCalledWith(
-        'claude-test',
+        "claude-test",
         expect.arrayContaining([
-          '-p',
-          'Test prompt', // No system context for timestamp
+          "-p",
+          "Test prompt", // No system context for timestamp
         ]),
-        expect.any(Object)
+        expect.any(Object),
       );
     });
   });
 
-  describe('Timestamp Conversion and Formatting', () => {
-    it('should correctly convert Unix timestamp to ISO string', async () => {
-      const { spawn } = await import('node:child_process');
+  describe("Timestamp Conversion and Formatting", () => {
+    it("should correctly convert Unix timestamp to ISO string", async () => {
+      const { spawn } = await import("node:child_process");
       const mockProcess = createMockChildProcess();
       vi.mocked(spawn).mockReturnValue(mockProcess);
 
       mockProcess.on = vi.fn((event, callback) => {
-        if (event === 'close') {
+        if (event === "close") {
           setTimeout(() => callback(0), 0);
         }
         return mockProcess;
@@ -199,19 +199,19 @@ describe('executeClaudeQuery - Timestamp Functionality', () => {
       const testCases = [
         {
           timestamp: 1709520000,
-          expectedIso: '2024-03-04T02:40:00.000Z',
-          description: 'Standard timestamp'
+          expectedIso: "2024-03-04T02:40:00.000Z",
+          description: "Standard timestamp",
         },
         {
           timestamp: 0,
-          expectedIso: '1970-01-01T00:00:00.000Z',
-          description: 'Unix epoch'
+          expectedIso: "1970-01-01T00:00:00.000Z",
+          description: "Unix epoch",
         },
         {
           timestamp: 1893456000,
-          expectedIso: '2030-01-01T00:00:00.000Z',
-          description: 'Future timestamp'
-        }
+          expectedIso: "2030-01-01T00:00:00.000Z",
+          description: "Future timestamp",
+        },
       ];
 
       for (const testCase of testCases) {
@@ -221,65 +221,69 @@ describe('executeClaudeQuery - Timestamp Functionality', () => {
         if (testCase.timestamp === 0) continue;
 
         executeClaudeQuery({
-          prompt: 'Test prompt',
-          userDir: '/test/user',
+          prompt: "Test prompt",
+          userDir: "/test/user",
           messageTimestamp: testCase.timestamp,
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1));
+        await new Promise((resolve) => setTimeout(resolve, 1));
 
         expect(spawn).toHaveBeenCalledWith(
-          'claude-test',
+          "claude-test",
           expect.arrayContaining([
-            '-p',
-            expect.stringContaining(`Message timestamp: ${testCase.expectedIso} (${testCase.timestamp})`)
+            "-p",
+            expect.stringContaining(
+              `Message timestamp: ${testCase.expectedIso} (${testCase.timestamp})`,
+            ),
           ]),
-          expect.any(Object)
+          expect.any(Object),
         );
       }
     });
 
-    it('should handle edge case timestamps correctly', async () => {
-      const { spawn } = await import('node:child_process');
+    it("should handle edge case timestamps correctly", async () => {
+      const { spawn } = await import("node:child_process");
       const mockProcess = createMockChildProcess();
       vi.mocked(spawn).mockReturnValue(mockProcess);
 
       mockProcess.on = vi.fn((event, callback) => {
-        if (event === 'close') {
+        if (event === "close") {
           setTimeout(() => callback(0), 0);
         }
         return mockProcess;
       });
 
-      // Test very large timestamp (year 2099)
-      const largeTimestamp = 4102444800; // 2099-12-31
+      // Test very large timestamp (year 2100)
+      const largeTimestamp = 4102444800; // 2100-01-01
       executeClaudeQuery({
-        prompt: 'Test prompt',
-        userDir: '/test/user',
+        prompt: "Test prompt",
+        userDir: "/test/user",
         messageTimestamp: largeTimestamp,
       });
 
-      await new Promise(resolve => setTimeout(resolve, 1));
+      await new Promise((resolve) => setTimeout(resolve, 1));
 
       expect(spawn).toHaveBeenCalledWith(
-        'claude-test',
+        "claude-test",
         expect.arrayContaining([
-          '-p',
-          expect.stringContaining(`Message timestamp: 2099-12-31T00:00:00.000Z (${largeTimestamp})`)
+          "-p",
+          expect.stringContaining(
+            `Message timestamp: 2100-01-01T00:00:00.000Z (${largeTimestamp})`,
+          ),
         ]),
-        expect.any(Object)
+        expect.any(Object),
       );
     });
   });
 
-  describe('Error Handling and Edge Cases', () => {
-    it('should handle negative timestamps', async () => {
-      const { spawn } = await import('node:child_process');
+  describe("Error Handling and Edge Cases", () => {
+    it("should handle negative timestamps", async () => {
+      const { spawn } = await import("node:child_process");
       const mockProcess = createMockChildProcess();
       vi.mocked(spawn).mockReturnValue(mockProcess);
 
       mockProcess.on = vi.fn((event, callback) => {
-        if (event === 'close') {
+        if (event === "close") {
           setTimeout(() => callback(0), 0);
         }
         return mockProcess;
@@ -288,31 +292,33 @@ describe('executeClaudeQuery - Timestamp Functionality', () => {
       // Negative timestamp should still work (before Unix epoch)
       const negativeTimestamp = -86400; // One day before epoch
       executeClaudeQuery({
-        prompt: 'Test prompt',
-        userDir: '/test/user',
+        prompt: "Test prompt",
+        userDir: "/test/user",
         messageTimestamp: negativeTimestamp,
       });
 
-      await new Promise(resolve => setTimeout(resolve, 1));
+      await new Promise((resolve) => setTimeout(resolve, 1));
 
       // Should still create ISO string (1969-12-31T00:00:00.000Z)
       expect(spawn).toHaveBeenCalledWith(
-        'claude-test',
+        "claude-test",
         expect.arrayContaining([
-          '-p',
-          expect.stringContaining('Message timestamp: 1969-12-31T00:00:00.000Z')
+          "-p",
+          expect.stringContaining(
+            "Message timestamp: 1969-12-31T00:00:00.000Z",
+          ),
         ]),
-        expect.any(Object)
+        expect.any(Object),
       );
     });
 
-    it('should handle very small positive timestamps', async () => {
-      const { spawn } = await import('node:child_process');
+    it("should handle very small positive timestamps", async () => {
+      const { spawn } = await import("node:child_process");
       const mockProcess = createMockChildProcess();
       vi.mocked(spawn).mockReturnValue(mockProcess);
 
       mockProcess.on = vi.fn((event, callback) => {
-        if (event === 'close') {
+        if (event === "close") {
           setTimeout(() => callback(0), 0);
         }
         return mockProcess;
@@ -321,74 +327,80 @@ describe('executeClaudeQuery - Timestamp Functionality', () => {
       // Small positive timestamp should work
       const smallTimestamp = 1;
       executeClaudeQuery({
-        prompt: 'Test prompt',
-        userDir: '/test/user',
+        prompt: "Test prompt",
+        userDir: "/test/user",
         messageTimestamp: smallTimestamp,
       });
 
-      await new Promise(resolve => setTimeout(resolve, 1));
+      await new Promise((resolve) => setTimeout(resolve, 1));
 
       expect(spawn).toHaveBeenCalledWith(
-        'claude-test',
+        "claude-test",
         expect.arrayContaining([
-          '-p',
-          expect.stringContaining('Message timestamp: 1970-01-01T00:00:01.000Z (1)')
+          "-p",
+          expect.stringContaining(
+            "Message timestamp: 1970-01-01T00:00:01.000Z (1)",
+          ),
         ]),
-        expect.any(Object)
+        expect.any(Object),
       );
     });
   });
 
-  describe('Integration with Other Options', () => {
-    it('should maintain all other executor functionality when timestamp is provided', async () => {
-      const { spawn } = await import('node:child_process');
+  describe("Integration with Other Options", () => {
+    it("should maintain all other executor functionality when timestamp is provided", async () => {
+      const { spawn } = await import("node:child_process");
       const mockProcess = createMockChildProcess();
       vi.mocked(spawn).mockReturnValue(mockProcess);
 
       mockProcess.on = vi.fn((event, callback) => {
-        if (event === 'close') {
+        if (event === "close") {
           setTimeout(() => callback(0), 0);
         }
         return mockProcess;
       });
 
       const options = {
-        prompt: 'Test prompt',
-        userDir: '/test/user',
-        downloadsPath: '/test/downloads',
-        sessionId: 'test-session-123',
+        prompt: "Test prompt",
+        userDir: "/test/user",
+        downloadsPath: "/test/downloads",
+        sessionId: "test-session-123",
         messageTimestamp: 1709520000,
         onProgress: vi.fn(),
       };
 
       executeClaudeQuery(options);
 
-      await new Promise(resolve => setTimeout(resolve, 1));
+      await new Promise((resolve) => setTimeout(resolve, 1));
 
       // Verify all CLI arguments are present
       expect(spawn).toHaveBeenCalledWith(
-        'claude-test',
+        "claude-test",
         [
-          '-p',
-          expect.stringContaining('Test prompt'),
-          '--output-format',
-          'stream-json',
-          '--verbose',
-          '--resume',
-          'test-session-123'
+          "-p",
+          expect.stringContaining("Test prompt"),
+          "--output-format",
+          "stream-json",
+          "--verbose",
+          "--resume",
+          "test-session-123",
         ],
         expect.objectContaining({
-          cwd: '/test/cwd',
+          cwd: "/test/cwd",
           env: process.env,
-          stdio: ['ignore', 'pipe', 'pipe']
-        })
+          stdio: ["ignore", "pipe", "pipe"],
+        }),
       );
 
       // Verify prompt includes both downloads path and timestamp
       const callArgs = vi.mocked(spawn).mock.calls[0][1];
-      const promptArg = callArgs[callArgs.indexOf('-p') + 1];
-      expect(promptArg).toContain('To send files to the user, write them to: /test/downloads');
-      expect(promptArg).toContain('Message timestamp: 2024-03-04T02:40:00.000Z (1709520000)');
+      const promptArg = callArgs[callArgs.indexOf("-p") + 1];
+      expect(promptArg).toContain(
+        "To send files to the user, write them to: /test/downloads",
+      );
+      expect(promptArg).toContain(
+        "Message timestamp: 2024-03-04T02:40:00.000Z (1709520000)",
+      );
     });
   });
 });

--- a/src/claude/__tests__/executor.test.ts
+++ b/src/claude/__tests__/executor.test.ts
@@ -1,0 +1,394 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { type ChildProcess } from 'node:child_process';
+import { executeClaudeQuery } from '../executor.js';
+import { getConfig, getWorkingDirectory } from '../../config.js';
+import { getLogger } from '../../logger.js';
+
+// Mock dependencies
+vi.mock('node:child_process');
+vi.mock('../../config.js');
+vi.mock('../../logger.js');
+
+// Create a mock child process
+const createMockChildProcess = () => {
+  const mockProcess = {
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+    on: vi.fn(),
+    kill: vi.fn()
+  } as unknown as ChildProcess;
+
+  return mockProcess;
+};
+
+describe('executeClaudeQuery - Timestamp Functionality', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Mock config
+    vi.mocked(getConfig).mockReturnValue({
+      claude: { command: 'claude-test' },
+      dataDir: '/test/data',
+    } as any);
+
+    // Mock working directory
+    vi.mocked(getWorkingDirectory).mockReturnValue('/test/cwd');
+
+    // Mock logger
+    vi.mocked(getLogger).mockReturnValue({
+      info: vi.fn(),
+      debug: vi.fn(),
+      error: vi.fn(),
+    } as any);
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('System Context Building', () => {
+    it('should include timestamp in system context when messageTimestamp is provided', async () => {
+      const { spawn } = await import('node:child_process');
+      const mockProcess = createMockChildProcess();
+      vi.mocked(spawn).mockReturnValue(mockProcess);
+
+      // Setup process to return successful result
+      mockProcess.on = vi.fn((event, callback) => {
+        if (event === 'close') {
+          setTimeout(() => callback(0), 0);
+        }
+        return mockProcess;
+      });
+
+      const testTimestamp = 1709520000; // Unix timestamp in seconds
+      const expectedIsoString = '2024-03-04T02:40:00.000Z';
+
+      executeClaudeQuery({
+        prompt: 'Test prompt',
+        userDir: '/test/user',
+        messageTimestamp: testTimestamp,
+      });
+
+      // Wait for spawn to be called
+      await new Promise(resolve => setTimeout(resolve, 1));
+
+      // Check that spawn was called with correct arguments
+      expect(spawn).toHaveBeenCalledWith(
+        'claude-test',
+        expect.arrayContaining([
+          '-p',
+          `Test prompt\n\n[System: Message timestamp: ${expectedIsoString} (${testTimestamp})]`,
+          '--output-format',
+          'stream-json',
+          '--verbose'
+        ]),
+        expect.any(Object)
+      );
+    });
+
+    it('should include both downloads path and timestamp when both are provided', async () => {
+      const { spawn } = await import('node:child_process');
+      const mockProcess = createMockChildProcess();
+      vi.mocked(spawn).mockReturnValue(mockProcess);
+
+      mockProcess.on = vi.fn((event, callback) => {
+        if (event === 'close') {
+          setTimeout(() => callback(0), 0);
+        }
+        return mockProcess;
+      });
+
+      const testTimestamp = 1709520000;
+      const expectedIsoString = '2024-03-04T02:40:00.000Z';
+      const downloadsPath = '/test/downloads';
+
+      executeClaudeQuery({
+        prompt: 'Test prompt',
+        userDir: '/test/user',
+        downloadsPath,
+        messageTimestamp: testTimestamp,
+      });
+
+      await new Promise(resolve => setTimeout(resolve, 1));
+
+      expect(spawn).toHaveBeenCalledWith(
+        'claude-test',
+        expect.arrayContaining([
+          '-p',
+          `Test prompt\n\n[System: To send files to the user, write them to: ${downloadsPath} | Message timestamp: ${expectedIsoString} (${testTimestamp})]`,
+        ]),
+        expect.any(Object)
+      );
+    });
+
+    it('should not include timestamp in system context when messageTimestamp is undefined', async () => {
+      const { spawn } = await import('node:child_process');
+      const mockProcess = createMockChildProcess();
+      vi.mocked(spawn).mockReturnValue(mockProcess);
+
+      mockProcess.on = vi.fn((event, callback) => {
+        if (event === 'close') {
+          setTimeout(() => callback(0), 0);
+        }
+        return mockProcess;
+      });
+
+      executeClaudeQuery({
+        prompt: 'Test prompt',
+        userDir: '/test/user',
+        // messageTimestamp is undefined
+      });
+
+      await new Promise(resolve => setTimeout(resolve, 1));
+
+      expect(spawn).toHaveBeenCalledWith(
+        'claude-test',
+        expect.arrayContaining([
+          '-p',
+          'Test prompt', // No system context appended
+        ]),
+        expect.any(Object)
+      );
+    });
+
+    it('should not include timestamp when messageTimestamp is 0', async () => {
+      const { spawn } = await import('node:child_process');
+      const mockProcess = createMockChildProcess();
+      vi.mocked(spawn).mockReturnValue(mockProcess);
+
+      mockProcess.on = vi.fn((event, callback) => {
+        if (event === 'close') {
+          setTimeout(() => callback(0), 0);
+        }
+        return mockProcess;
+      });
+
+      executeClaudeQuery({
+        prompt: 'Test prompt',
+        userDir: '/test/user',
+        messageTimestamp: 0, // Falsy value
+      });
+
+      await new Promise(resolve => setTimeout(resolve, 1));
+
+      expect(spawn).toHaveBeenCalledWith(
+        'claude-test',
+        expect.arrayContaining([
+          '-p',
+          'Test prompt', // No system context for timestamp
+        ]),
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe('Timestamp Conversion and Formatting', () => {
+    it('should correctly convert Unix timestamp to ISO string', async () => {
+      const { spawn } = await import('node:child_process');
+      const mockProcess = createMockChildProcess();
+      vi.mocked(spawn).mockReturnValue(mockProcess);
+
+      mockProcess.on = vi.fn((event, callback) => {
+        if (event === 'close') {
+          setTimeout(() => callback(0), 0);
+        }
+        return mockProcess;
+      });
+
+      // Test various timestamp values
+      const testCases = [
+        {
+          timestamp: 1709520000,
+          expectedIso: '2024-03-04T02:40:00.000Z',
+          description: 'Standard timestamp'
+        },
+        {
+          timestamp: 0,
+          expectedIso: '1970-01-01T00:00:00.000Z',
+          description: 'Unix epoch'
+        },
+        {
+          timestamp: 1893456000,
+          expectedIso: '2030-01-01T00:00:00.000Z',
+          description: 'Future timestamp'
+        }
+      ];
+
+      for (const testCase of testCases) {
+        vi.clearAllMocks();
+
+        // Skip timestamp 0 since it's handled as falsy
+        if (testCase.timestamp === 0) continue;
+
+        executeClaudeQuery({
+          prompt: 'Test prompt',
+          userDir: '/test/user',
+          messageTimestamp: testCase.timestamp,
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1));
+
+        expect(spawn).toHaveBeenCalledWith(
+          'claude-test',
+          expect.arrayContaining([
+            '-p',
+            expect.stringContaining(`Message timestamp: ${testCase.expectedIso} (${testCase.timestamp})`)
+          ]),
+          expect.any(Object)
+        );
+      }
+    });
+
+    it('should handle edge case timestamps correctly', async () => {
+      const { spawn } = await import('node:child_process');
+      const mockProcess = createMockChildProcess();
+      vi.mocked(spawn).mockReturnValue(mockProcess);
+
+      mockProcess.on = vi.fn((event, callback) => {
+        if (event === 'close') {
+          setTimeout(() => callback(0), 0);
+        }
+        return mockProcess;
+      });
+
+      // Test very large timestamp (year 2099)
+      const largeTimestamp = 4102444800; // 2099-12-31
+      executeClaudeQuery({
+        prompt: 'Test prompt',
+        userDir: '/test/user',
+        messageTimestamp: largeTimestamp,
+      });
+
+      await new Promise(resolve => setTimeout(resolve, 1));
+
+      expect(spawn).toHaveBeenCalledWith(
+        'claude-test',
+        expect.arrayContaining([
+          '-p',
+          expect.stringContaining(`Message timestamp: 2099-12-31T00:00:00.000Z (${largeTimestamp})`)
+        ]),
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe('Error Handling and Edge Cases', () => {
+    it('should handle negative timestamps', async () => {
+      const { spawn } = await import('node:child_process');
+      const mockProcess = createMockChildProcess();
+      vi.mocked(spawn).mockReturnValue(mockProcess);
+
+      mockProcess.on = vi.fn((event, callback) => {
+        if (event === 'close') {
+          setTimeout(() => callback(0), 0);
+        }
+        return mockProcess;
+      });
+
+      // Negative timestamp should still work (before Unix epoch)
+      const negativeTimestamp = -86400; // One day before epoch
+      executeClaudeQuery({
+        prompt: 'Test prompt',
+        userDir: '/test/user',
+        messageTimestamp: negativeTimestamp,
+      });
+
+      await new Promise(resolve => setTimeout(resolve, 1));
+
+      // Should still create ISO string (1969-12-31T00:00:00.000Z)
+      expect(spawn).toHaveBeenCalledWith(
+        'claude-test',
+        expect.arrayContaining([
+          '-p',
+          expect.stringContaining('Message timestamp: 1969-12-31T00:00:00.000Z')
+        ]),
+        expect.any(Object)
+      );
+    });
+
+    it('should handle very small positive timestamps', async () => {
+      const { spawn } = await import('node:child_process');
+      const mockProcess = createMockChildProcess();
+      vi.mocked(spawn).mockReturnValue(mockProcess);
+
+      mockProcess.on = vi.fn((event, callback) => {
+        if (event === 'close') {
+          setTimeout(() => callback(0), 0);
+        }
+        return mockProcess;
+      });
+
+      // Small positive timestamp should work
+      const smallTimestamp = 1;
+      executeClaudeQuery({
+        prompt: 'Test prompt',
+        userDir: '/test/user',
+        messageTimestamp: smallTimestamp,
+      });
+
+      await new Promise(resolve => setTimeout(resolve, 1));
+
+      expect(spawn).toHaveBeenCalledWith(
+        'claude-test',
+        expect.arrayContaining([
+          '-p',
+          expect.stringContaining('Message timestamp: 1970-01-01T00:00:01.000Z (1)')
+        ]),
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe('Integration with Other Options', () => {
+    it('should maintain all other executor functionality when timestamp is provided', async () => {
+      const { spawn } = await import('node:child_process');
+      const mockProcess = createMockChildProcess();
+      vi.mocked(spawn).mockReturnValue(mockProcess);
+
+      mockProcess.on = vi.fn((event, callback) => {
+        if (event === 'close') {
+          setTimeout(() => callback(0), 0);
+        }
+        return mockProcess;
+      });
+
+      const options = {
+        prompt: 'Test prompt',
+        userDir: '/test/user',
+        downloadsPath: '/test/downloads',
+        sessionId: 'test-session-123',
+        messageTimestamp: 1709520000,
+        onProgress: vi.fn(),
+      };
+
+      executeClaudeQuery(options);
+
+      await new Promise(resolve => setTimeout(resolve, 1));
+
+      // Verify all CLI arguments are present
+      expect(spawn).toHaveBeenCalledWith(
+        'claude-test',
+        [
+          '-p',
+          expect.stringContaining('Test prompt'),
+          '--output-format',
+          'stream-json',
+          '--verbose',
+          '--resume',
+          'test-session-123'
+        ],
+        expect.objectContaining({
+          cwd: '/test/cwd',
+          env: process.env,
+          stdio: ['ignore', 'pipe', 'pipe']
+        })
+      );
+
+      // Verify prompt includes both downloads path and timestamp
+      const callArgs = vi.mocked(spawn).mock.calls[0][1];
+      const promptArg = callArgs[callArgs.indexOf('-p') + 1];
+      expect(promptArg).toContain('To send files to the user, write them to: /test/downloads');
+      expect(promptArg).toContain('Message timestamp: 2024-03-04T02:40:00.000Z (1709520000)');
+    });
+  });
+});

--- a/src/claude/commandExecutor.improved.ts
+++ b/src/claude/commandExecutor.improved.ts
@@ -1,0 +1,363 @@
+import { join, resolve } from "node:path";
+import type { Context } from "grammy";
+import { getConfig } from "../config.js";
+import { getLogger } from "../logger.js";
+import { sendChunkedResponse } from "../telegram/chunker.js";
+import { sendDownloadFiles } from "../telegram/fileSender.js";
+import {
+  ensureUserSetup,
+  getDownloadsPath,
+  getSessionId,
+  saveSessionId,
+} from "../user/setup.js";
+import { getValidClaudeCommand } from "./commands.improved.js";
+import { executeClaudeQuery } from "./executor.js";
+
+/**
+ * Rate limiting for command execution to prevent abuse
+ */
+const userCommandCooldown = new Map<number, number>();
+const COOLDOWN_DURATION = 2000; // 2 seconds between commands per user
+
+/**
+ * Check if user is rate limited
+ */
+function isRateLimited(userId: number): boolean {
+  const lastExecution = userCommandCooldown.get(userId);
+  if (!lastExecution) {
+    return false;
+  }
+
+  const timeSinceLastExecution = Date.now() - lastExecution;
+  return timeSinceLastExecution < COOLDOWN_DURATION;
+}
+
+/**
+ * Update user's rate limit timestamp
+ */
+function updateRateLimit(userId: number): void {
+  userCommandCooldown.set(userId, Date.now());
+}
+
+/**
+ * Sanitize command arguments to prevent injection attacks
+ */
+function sanitizeArguments(args: string): string {
+  return args
+    // Remove or escape potentially dangerous sequences
+    .replace(/[<>]/g, '') // Remove HTML-like brackets
+    .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '') // Remove control characters
+    .replace(/\${[^}]*}/g, '') // Remove variable interpolation patterns
+    .trim()
+    .slice(0, 1000); // Limit argument length
+}
+
+/**
+ * Validate command execution context
+ */
+function validateExecutionContext(ctx: Context): { isValid: boolean; error?: string } {
+  // Check for user ID
+  if (!ctx.from?.id) {
+    return { isValid: false, error: 'Unable to identify user' };
+  }
+
+  // Check for chat context
+  if (!ctx.chat?.id) {
+    return { isValid: false, error: 'Invalid chat context' };
+  }
+
+  // Check if user is a bot (prevent bot-to-bot interactions)
+  if (ctx.from.is_bot) {
+    return { isValid: false, error: 'Bot users cannot execute commands' };
+  }
+
+  return { isValid: true };
+}
+
+/**
+ * Enhanced progress tracking with throttling and error recovery
+ */
+class ProgressTracker {
+  private lastUpdate = 0;
+  private lastMessage = '';
+  private updateCount = 0;
+  private readonly throttleMs = 2000;
+  private readonly maxUpdates = 10;
+
+  constructor(
+    private ctx: Context,
+    private statusMessageId: number,
+    private logger: any
+  ) {}
+
+  async updateProgress(message: string): Promise<void> {
+    const now = Date.now();
+
+    // Throttle updates and prevent spam
+    if (
+      now - this.lastUpdate < this.throttleMs ||
+      message === this.lastMessage ||
+      this.updateCount >= this.maxUpdates
+    ) {
+      return;
+    }
+
+    this.lastUpdate = now;
+    this.lastMessage = message;
+    this.updateCount++;
+
+    try {
+      await this.ctx.api.editMessageText(
+        this.ctx.chat!.id,
+        this.statusMessageId,
+        `_${message}_`,
+        { parse_mode: 'Markdown' }
+      );
+    } catch (error) {
+      // Log error but don't fail the command execution
+      this.logger.debug({ error, message }, 'Failed to update progress message');
+    }
+  }
+
+  async cleanup(): Promise<void> {
+    try {
+      await this.ctx.api.deleteMessage(this.ctx.chat!.id, this.statusMessageId);
+    } catch (error) {
+      // Deletion failures are not critical
+      this.logger.debug({ error }, 'Failed to delete status message');
+    }
+  }
+}
+
+/**
+ * Execute a Claude command with enhanced validation, rate limiting, and error handling
+ */
+export async function executeClaudeCommand(
+  ctx: Context,
+  commandName: string,
+  args?: string,
+): Promise<void> {
+  const logger = getLogger();
+  const config = getConfig();
+
+  // Validate execution context
+  const contextValidation = validateExecutionContext(ctx);
+  if (!contextValidation.isValid) {
+    await ctx.reply(`❌ ${contextValidation.error}`);
+    return;
+  }
+
+  const userId = ctx.from!.id;
+  logger.debug({
+    commandName,
+    args: args ? args.slice(0, 100) + (args.length > 100 ? '...' : '') : undefined,
+    userId,
+    username: ctx.from?.username,
+  }, 'Claude command execution requested');
+
+  // Check rate limiting
+  if (isRateLimited(userId)) {
+    await ctx.reply(
+      '⏳ Please wait a moment before executing another command.',
+      { parse_mode: 'Markdown' }
+    );
+    return;
+  }
+
+  // Update rate limit
+  updateRateLimit(userId);
+
+  try {
+    // Get and validate the Claude command
+    const command = await getValidClaudeCommand(commandName);
+    if (!command) {
+      await ctx.reply(
+        `❌ Command \`${commandName}\` not found or invalid.`,
+        { parse_mode: 'Markdown' }
+      );
+      logger.warn({ commandName }, 'Attempted to execute non-existent or invalid command');
+      return;
+    }
+
+    // Validate and sanitize arguments
+    let sanitizedArgs: string | undefined;
+    if (args?.trim()) {
+      sanitizedArgs = sanitizeArguments(args.trim());
+      if (sanitizedArgs !== args.trim()) {
+        logger.info({ commandName, userId }, 'Command arguments were sanitized');
+      }
+    }
+
+    const userDir = resolve(join(config.dataDir, String(userId)));
+
+    // Set up user directory with enhanced error handling
+    try {
+      await ensureUserSetup(userDir);
+    } catch (setupError) {
+      logger.error({ error: setupError, userId, userDir }, 'User setup failed');
+      await ctx.reply(
+        '❌ Failed to set up user environment. Please try again later.',
+        { parse_mode: 'Markdown' }
+      );
+      return;
+    }
+
+    // Prepare the command prompt
+    let prompt = `/${commandName}`;
+    if (sanitizedArgs) {
+      prompt += ` ${sanitizedArgs}`;
+    }
+
+    // Get session and downloads path
+    const sessionId = await getSessionId(userDir);
+    const downloadsPath = getDownloadsPath(userDir);
+
+    // Send initial status message
+    const statusMsg = await ctx.reply('_Executing command..._', {
+      parse_mode: 'Markdown',
+    });
+
+    const progressTracker = new ProgressTracker(ctx, statusMsg.message_id, logger);
+
+    // Execute the Claude command with enhanced error handling
+    logger.debug({ commandName, userId }, 'Starting Claude command execution');
+
+    const startTime = Date.now();
+    let result;
+
+    try {
+      result = await executeClaudeQuery({
+        prompt,
+        userDir,
+        downloadsPath,
+        sessionId,
+        onProgress: (message: string) => progressTracker.updateProgress(message),
+      });
+    } catch (executionError) {
+      logger.error({
+        error: executionError,
+        commandName,
+        userId,
+        prompt: prompt.slice(0, 200),
+      }, 'Claude command execution failed');
+
+      await progressTracker.cleanup();
+
+      await ctx.reply(
+        `❌ Failed to execute command \`${commandName}\`.\n\nError: ${
+          executionError instanceof Error ? executionError.message : String(executionError)
+        }`,
+        { parse_mode: 'Markdown' }
+      );
+      return;
+    }
+
+    const executionTime = Date.now() - startTime;
+
+    // Clean up progress tracking
+    await progressTracker.cleanup();
+
+    // Save session ID if received
+    if (result.sessionId) {
+      try {
+        await saveSessionId(userDir, result.sessionId);
+        logger.debug({ sessionId: result.sessionId }, 'Session saved');
+      } catch (sessionError) {
+        logger.warn({ error: sessionError }, 'Failed to save session ID');
+      }
+    }
+
+    // Send the response with improved formatting
+    const responseText = result.success
+      ? result.output
+      : result.error || 'An error occurred executing the command';
+
+    try {
+      await sendChunkedResponse(ctx, responseText);
+    } catch (responseError) {
+      logger.error({ error: responseError }, 'Failed to send command response');
+      await ctx.reply(
+        '❌ Command executed but failed to send response. Please try again.',
+        { parse_mode: 'Markdown' }
+      );
+      return;
+    }
+
+    // Send any files from downloads folder
+    let filesSent = 0;
+    try {
+      filesSent = await sendDownloadFiles(ctx, userDir);
+      if (filesSent > 0) {
+        logger.info({ filesSent, commandName, userId }, 'Sent download files to user');
+      }
+    } catch (fileError) {
+      logger.warn({ error: fileError }, 'Failed to send download files');
+    }
+
+    // Log successful completion with metrics
+    logger.info({
+      commandName,
+      args: sanitizedArgs,
+      userId,
+      username: ctx.from?.username,
+      success: result.success,
+      executionTimeMs: executionTime,
+      filesSent,
+      outputLength: responseText.length,
+    }, 'Claude command executed successfully');
+
+  } catch (error) {
+    // Top-level error handler for unexpected errors
+    logger.error({
+      error,
+      commandName,
+      args,
+      userId,
+    }, 'Unexpected error in executeClaudeCommand');
+
+    try {
+      await ctx.reply(
+        `❌ An unexpected error occurred while executing \`${commandName}\`. Please try again later.`,
+        { parse_mode: 'Markdown' }
+      );
+    } catch (replyError) {
+      logger.error({ error: replyError }, 'Failed to send error reply');
+    }
+  }
+}
+
+/**
+ * Get command execution statistics for monitoring
+ */
+export function getCommandExecutionStats(): {
+  activeUsers: number;
+  rateLimitedUsers: number;
+} {
+  const now = Date.now();
+  let rateLimitedUsers = 0;
+
+  for (const [, lastExecution] of userCommandCooldown) {
+    if (now - lastExecution < COOLDOWN_DURATION) {
+      rateLimitedUsers++;
+    }
+  }
+
+  return {
+    activeUsers: userCommandCooldown.size,
+    rateLimitedUsers,
+  };
+}
+
+/**
+ * Clear rate limiting for a specific user (admin function)
+ */
+export function clearUserRateLimit(userId: number): void {
+  userCommandCooldown.delete(userId);
+}
+
+/**
+ * Clear all rate limiting (admin function)
+ */
+export function clearAllRateLimits(): void {
+  userCommandCooldown.clear();
+}

--- a/src/claude/commandExecutor.improved.ts
+++ b/src/claude/commandExecutor.improved.ts
@@ -43,32 +43,37 @@ function updateRateLimit(userId: number): void {
  * Sanitize command arguments to prevent injection attacks
  */
 function sanitizeArguments(args: string): string {
-  return args
-    // Remove or escape potentially dangerous sequences
-    .replace(/[<>]/g, '') // Remove HTML-like brackets
-    .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '') // Remove control characters
-    .replace(/\${[^}]*}/g, '') // Remove variable interpolation patterns
-    .trim()
-    .slice(0, 1000); // Limit argument length
+  return (
+    args
+      // Remove or escape potentially dangerous sequences
+      .replace(/[<>]/g, "") // Remove HTML-like brackets
+      .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "") // Remove control characters
+      .replace(/\${[^}]*}/g, "") // Remove variable interpolation patterns
+      .trim()
+      .slice(0, 1000)
+  ); // Limit argument length
 }
 
 /**
  * Validate command execution context
  */
-function validateExecutionContext(ctx: Context): { isValid: boolean; error?: string } {
+function validateExecutionContext(ctx: Context): {
+  isValid: boolean;
+  error?: string;
+} {
   // Check for user ID
   if (!ctx.from?.id) {
-    return { isValid: false, error: 'Unable to identify user' };
+    return { isValid: false, error: "Unable to identify user" };
   }
 
   // Check for chat context
   if (!ctx.chat?.id) {
-    return { isValid: false, error: 'Invalid chat context' };
+    return { isValid: false, error: "Invalid chat context" };
   }
 
   // Check if user is a bot (prevent bot-to-bot interactions)
   if (ctx.from.is_bot) {
-    return { isValid: false, error: 'Bot users cannot execute commands' };
+    return { isValid: false, error: "Bot users cannot execute commands" };
   }
 
   return { isValid: true };
@@ -79,7 +84,7 @@ function validateExecutionContext(ctx: Context): { isValid: boolean; error?: str
  */
 class ProgressTracker {
   private lastUpdate = 0;
-  private lastMessage = '';
+  private lastMessage = "";
   private updateCount = 0;
   private readonly throttleMs = 2000;
   private readonly maxUpdates = 10;
@@ -87,7 +92,7 @@ class ProgressTracker {
   constructor(
     private ctx: Context,
     private statusMessageId: number,
-    private logger: any
+    private logger: any,
   ) {}
 
   async updateProgress(message: string): Promise<void> {
@@ -111,11 +116,14 @@ class ProgressTracker {
         this.ctx.chat!.id,
         this.statusMessageId,
         `_${message}_`,
-        { parse_mode: 'Markdown' }
+        { parse_mode: "Markdown" },
       );
     } catch (error) {
       // Log error but don't fail the command execution
-      this.logger.debug({ error, message }, 'Failed to update progress message');
+      this.logger.debug(
+        { error, message },
+        "Failed to update progress message",
+      );
     }
   }
 
@@ -124,7 +132,7 @@ class ProgressTracker {
       await this.ctx.api.deleteMessage(this.ctx.chat!.id, this.statusMessageId);
     } catch (error) {
       // Deletion failures are not critical
-      this.logger.debug({ error }, 'Failed to delete status message');
+      this.logger.debug({ error }, "Failed to delete status message");
     }
   }
 }
@@ -148,18 +156,23 @@ export async function executeClaudeCommand(
   }
 
   const userId = ctx.from!.id;
-  logger.debug({
-    commandName,
-    args: args ? args.slice(0, 100) + (args.length > 100 ? '...' : '') : undefined,
-    userId,
-    username: ctx.from?.username,
-  }, 'Claude command execution requested');
+  logger.debug(
+    {
+      commandName,
+      args: args
+        ? args.slice(0, 100) + (args.length > 100 ? "..." : "")
+        : undefined,
+      userId,
+      username: ctx.from?.username,
+    },
+    "Claude command execution requested",
+  );
 
   // Check rate limiting
   if (isRateLimited(userId)) {
     await ctx.reply(
-      '⏳ Please wait a moment before executing another command.',
-      { parse_mode: 'Markdown' }
+      "⏳ Please wait a moment before executing another command.",
+      { parse_mode: "Markdown" },
     );
     return;
   }
@@ -171,11 +184,13 @@ export async function executeClaudeCommand(
     // Get and validate the Claude command
     const command = await getValidClaudeCommand(commandName);
     if (!command) {
-      await ctx.reply(
-        `❌ Command \`${commandName}\` not found or invalid.`,
-        { parse_mode: 'Markdown' }
+      await ctx.reply(`❌ Command \`${commandName}\` not found or invalid.`, {
+        parse_mode: "Markdown",
+      });
+      logger.warn(
+        { commandName },
+        "Attempted to execute non-existent or invalid command",
       );
-      logger.warn({ commandName }, 'Attempted to execute non-existent or invalid command');
       return;
     }
 
@@ -184,7 +199,10 @@ export async function executeClaudeCommand(
     if (args?.trim()) {
       sanitizedArgs = sanitizeArguments(args.trim());
       if (sanitizedArgs !== args.trim()) {
-        logger.info({ commandName, userId }, 'Command arguments were sanitized');
+        logger.info(
+          { commandName, userId },
+          "Command arguments were sanitized",
+        );
       }
     }
 
@@ -194,10 +212,10 @@ export async function executeClaudeCommand(
     try {
       await ensureUserSetup(userDir);
     } catch (setupError) {
-      logger.error({ error: setupError, userId, userDir }, 'User setup failed');
+      logger.error({ error: setupError, userId, userDir }, "User setup failed");
       await ctx.reply(
-        '❌ Failed to set up user environment. Please try again later.',
-        { parse_mode: 'Markdown' }
+        "❌ Failed to set up user environment. Please try again later.",
+        { parse_mode: "Markdown" },
       );
       return;
     }
@@ -213,14 +231,18 @@ export async function executeClaudeCommand(
     const downloadsPath = getDownloadsPath(userDir);
 
     // Send initial status message
-    const statusMsg = await ctx.reply('_Executing command..._', {
-      parse_mode: 'Markdown',
+    const statusMsg = await ctx.reply("_Executing command..._", {
+      parse_mode: "Markdown",
     });
 
-    const progressTracker = new ProgressTracker(ctx, statusMsg.message_id, logger);
+    const progressTracker = new ProgressTracker(
+      ctx,
+      statusMsg.message_id,
+      logger,
+    );
 
     // Execute the Claude command with enhanced error handling
-    logger.debug({ commandName, userId }, 'Starting Claude command execution');
+    logger.debug({ commandName, userId }, "Starting Claude command execution");
 
     const startTime = Date.now();
     let result;
@@ -231,23 +253,29 @@ export async function executeClaudeCommand(
         userDir,
         downloadsPath,
         sessionId,
-        onProgress: (message: string) => progressTracker.updateProgress(message),
+        onProgress: (message: string) =>
+          progressTracker.updateProgress(message),
       });
     } catch (executionError) {
-      logger.error({
-        error: executionError,
-        commandName,
-        userId,
-        prompt: prompt.slice(0, 200),
-      }, 'Claude command execution failed');
+      logger.error(
+        {
+          error: executionError,
+          commandName,
+          userId,
+          prompt: prompt.slice(0, 200),
+        },
+        "Claude command execution failed",
+      );
 
       await progressTracker.cleanup();
 
       await ctx.reply(
         `❌ Failed to execute command \`${commandName}\`.\n\nError: ${
-          executionError instanceof Error ? executionError.message : String(executionError)
+          executionError instanceof Error
+            ? executionError.message
+            : String(executionError)
         }`,
-        { parse_mode: 'Markdown' }
+        { parse_mode: "Markdown" },
       );
       return;
     }
@@ -261,24 +289,24 @@ export async function executeClaudeCommand(
     if (result.sessionId) {
       try {
         await saveSessionId(userDir, result.sessionId);
-        logger.debug({ sessionId: result.sessionId }, 'Session saved');
+        logger.debug({ sessionId: result.sessionId }, "Session saved");
       } catch (sessionError) {
-        logger.warn({ error: sessionError }, 'Failed to save session ID');
+        logger.warn({ error: sessionError }, "Failed to save session ID");
       }
     }
 
     // Send the response with improved formatting
     const responseText = result.success
       ? result.output
-      : result.error || 'An error occurred executing the command';
+      : result.error || "An error occurred executing the command";
 
     try {
       await sendChunkedResponse(ctx, responseText);
     } catch (responseError) {
-      logger.error({ error: responseError }, 'Failed to send command response');
+      logger.error({ error: responseError }, "Failed to send command response");
       await ctx.reply(
-        '❌ Command executed but failed to send response. Please try again.',
-        { parse_mode: 'Markdown' }
+        "❌ Command executed but failed to send response. Please try again.",
+        { parse_mode: "Markdown" },
       );
       return;
     }
@@ -288,40 +316,48 @@ export async function executeClaudeCommand(
     try {
       filesSent = await sendDownloadFiles(ctx, userDir);
       if (filesSent > 0) {
-        logger.info({ filesSent, commandName, userId }, 'Sent download files to user');
+        logger.info(
+          { filesSent, commandName, userId },
+          "Sent download files to user",
+        );
       }
     } catch (fileError) {
-      logger.warn({ error: fileError }, 'Failed to send download files');
+      logger.warn({ error: fileError }, "Failed to send download files");
     }
 
     // Log successful completion with metrics
-    logger.info({
-      commandName,
-      args: sanitizedArgs,
-      userId,
-      username: ctx.from?.username,
-      success: result.success,
-      executionTimeMs: executionTime,
-      filesSent,
-      outputLength: responseText.length,
-    }, 'Claude command executed successfully');
-
+    logger.info(
+      {
+        commandName,
+        args: sanitizedArgs,
+        userId,
+        username: ctx.from?.username,
+        success: result.success,
+        executionTimeMs: executionTime,
+        filesSent,
+        outputLength: responseText.length,
+      },
+      "Claude command executed successfully",
+    );
   } catch (error) {
     // Top-level error handler for unexpected errors
-    logger.error({
-      error,
-      commandName,
-      args,
-      userId,
-    }, 'Unexpected error in executeClaudeCommand');
+    logger.error(
+      {
+        error,
+        commandName,
+        args,
+        userId,
+      },
+      "Unexpected error in executeClaudeCommand",
+    );
 
     try {
       await ctx.reply(
         `❌ An unexpected error occurred while executing \`${commandName}\`. Please try again later.`,
-        { parse_mode: 'Markdown' }
+        { parse_mode: "Markdown" },
       );
     } catch (replyError) {
-      logger.error({ error: replyError }, 'Failed to send error reply');
+      logger.error({ error: replyError }, "Failed to send error reply");
     }
   }
 }

--- a/src/claude/commandExecutor.improved.ts
+++ b/src/claude/commandExecutor.improved.ts
@@ -11,7 +11,7 @@ import {
   saveSessionId,
 } from "../user/setup.js";
 import { getValidClaudeCommand } from "./commands.improved.js";
-import { executeClaudeQuery } from "./executor.js";
+import { type ExecuteResult, executeClaudeQuery } from "./executor.js";
 
 /**
  * Rate limiting for command execution to prevent abuse
@@ -47,7 +47,19 @@ function sanitizeArguments(args: string): string {
     args
       // Remove or escape potentially dangerous sequences
       .replace(/[<>]/g, "") // Remove HTML-like brackets
-      .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "") // Remove control characters
+      .split("")
+      .filter((char) => {
+        const code = char.charCodeAt(0);
+        // Remove control characters (0-8, 11, 12, 14-31, 127)
+        return !(
+          code <= 8 ||
+          code === 11 ||
+          code === 12 ||
+          (code >= 14 && code <= 31) ||
+          code === 127
+        );
+      })
+      .join("")
       .replace(/\${[^}]*}/g, "") // Remove variable interpolation patterns
       .trim()
       .slice(0, 1000)
@@ -92,7 +104,7 @@ class ProgressTracker {
   constructor(
     private ctx: Context,
     private statusMessageId: number,
-    private logger: any,
+    private logger: ReturnType<typeof import("../logger.js").getLogger>,
   ) {}
 
   async updateProgress(message: string): Promise<void> {
@@ -245,7 +257,7 @@ export async function executeClaudeCommand(
     logger.debug({ commandName, userId }, "Starting Claude command execution");
 
     const startTime = Date.now();
-    let result;
+    let result: ExecuteResult;
 
     try {
       result = await executeClaudeQuery({

--- a/src/claude/commandExecutor.ts
+++ b/src/claude/commandExecutor.ts
@@ -35,6 +35,7 @@ export async function executeClaudeCommand(
   }
 
   const userId = ctx.from?.id;
+  const messageTimestamp = ctx.message?.date;
   if (!userId) {
     await ctx.reply("❌ Unable to identify user.");
     return;
@@ -91,6 +92,7 @@ export async function executeClaudeCommand(
       downloadsPath,
       sessionId,
       onProgress,
+      messageTimestamp,
     });
 
     // Delete status message

--- a/src/claude/commandExecutor.ts
+++ b/src/claude/commandExecutor.ts
@@ -1,0 +1,136 @@
+import { join, resolve } from "node:path";
+import type { Context } from "grammy";
+import { getConfig } from "../config.js";
+import { getLogger } from "../logger.js";
+import { sendChunkedResponse } from "../telegram/chunker.js";
+import { sendDownloadFiles } from "../telegram/fileSender.js";
+import {
+  ensureUserSetup,
+  getDownloadsPath,
+  getSessionId,
+  saveSessionId,
+} from "../user/setup.js";
+import { getClaudeCommand } from "./commands.js";
+import { executeClaudeQuery } from "./executor.js";
+
+/**
+ * Execute a Claude command triggered by Telegram
+ */
+export async function executeClaudeCommand(
+  ctx: Context,
+  commandName: string,
+  args?: string,
+): Promise<void> {
+  const logger = getLogger();
+  const config = getConfig();
+  logger.debug({ commandName, args }, "Executing Claude command");
+
+  // Get the Claude command definition
+  const command = await getClaudeCommand(commandName);
+  if (!command) {
+    await ctx.reply(`❌ Command \`${commandName}\` not found.`, {
+      parse_mode: "Markdown",
+    });
+    return;
+  }
+
+  const userId = ctx.from?.id;
+  if (!userId) {
+    await ctx.reply("❌ Unable to identify user.");
+    return;
+  }
+
+  const userDir = resolve(join(config.dataDir, String(userId)));
+
+  try {
+    // Set up user directory
+    await ensureUserSetup(userDir);
+
+    // Prepare the command prompt
+    let prompt = `/${commandName}`;
+    if (args?.trim()) {
+      prompt += ` ${args.trim()}`;
+    }
+
+    // Get session and downloads path
+    const sessionId = await getSessionId(userDir);
+    const downloadsPath = getDownloadsPath(userDir);
+
+    // Send initial status message
+    const statusMsg = await ctx.reply("_Executing command..._", {
+      parse_mode: "Markdown",
+    });
+
+    // Progress callback
+    let lastProgressUpdate = Date.now();
+    let lastProgressText = "Executing command...";
+
+    const onProgress = async (message: string) => {
+      const now = Date.now();
+      if (now - lastProgressUpdate > 2000 && message !== lastProgressText) {
+        lastProgressUpdate = now;
+        lastProgressText = message;
+        try {
+          await ctx.api.editMessageText(
+            ctx.chat!.id,
+            statusMsg.message_id,
+            `_${message}_`,
+            { parse_mode: "Markdown" },
+          );
+        } catch {
+          // Ignore edit errors
+        }
+      }
+    };
+
+    // Execute the Claude command
+    logger.debug("Executing Claude command query");
+    const result = await executeClaudeQuery({
+      prompt,
+      userDir,
+      downloadsPath,
+      sessionId,
+      onProgress,
+    });
+
+    // Delete status message
+    try {
+      await ctx.api.deleteMessage(ctx.chat!.id, statusMsg.message_id);
+    } catch {
+      // Ignore delete errors
+    }
+
+    // Save session ID if received
+    if (result.sessionId) {
+      await saveSessionId(userDir, result.sessionId);
+      logger.debug({ sessionId: result.sessionId }, "Session saved");
+    }
+
+    // Send the response
+    const responseText = result.success
+      ? result.output
+      : result.error || "An error occurred executing the command";
+
+    await sendChunkedResponse(ctx, responseText);
+
+    // Send any files from downloads folder
+    const filesSent = await sendDownloadFiles(ctx, userDir);
+    if (filesSent > 0) {
+      logger.info({ filesSent, commandName }, "Sent download files to user");
+    }
+
+    logger.info(
+      { commandName, args, userId, success: result.success },
+      "Claude command executed",
+    );
+  } catch (error) {
+    logger.error(
+      { error, commandName, args },
+      "Failed to execute Claude command",
+    );
+    await ctx.reply(
+      `❌ Failed to execute command \`${commandName}\`.\n\nError: ${error instanceof Error ? error.message : String(error)}`,
+      { parse_mode: "Markdown" },
+    );
+  }
+}

--- a/src/claude/commands.improved.ts
+++ b/src/claude/commands.improved.ts
@@ -25,22 +25,25 @@ const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes in milliseconds
 
 // Built-in Telegram bot commands that should not be overridden
 const BUILT_IN_COMMANDS = new Set([
-  'start',
-  'help',
-  'clear',
-  'stop',
-  'restart',
-  'settings',
-  'version',
-  'status',
-  'ping',
-  'cancel',
+  "start",
+  "help",
+  "clear",
+  "stop",
+  "restart",
+  "settings",
+  "version",
+  "status",
+  "ping",
+  "cancel",
 ]);
 
 /**
  * Validate command name to prevent conflicts and security issues
  */
-function validateCommandName(name: string): { isValid: boolean; error?: string } {
+function validateCommandName(name: string): {
+  isValid: boolean;
+  error?: string;
+} {
   // Check for built-in command conflicts
   if (BUILT_IN_COMMANDS.has(name)) {
     return {
@@ -61,7 +64,7 @@ function validateCommandName(name: string): { isValid: boolean; error?: string }
   if (name.length < 1) {
     return {
       isValid: false,
-      error: 'Command name cannot be empty',
+      error: "Command name cannot be empty",
     };
   }
 
@@ -89,8 +92,8 @@ function validateCommandName(name: string): { isValid: boolean; error?: string }
 function sanitizeDescription(description: string): string {
   // Remove or escape potentially dangerous characters
   return description
-    .replace(/[<>]/g, '') // Remove HTML-like brackets
-    .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '') // Remove control characters
+    .replace(/[<>]/g, "") // Remove HTML-like brackets
+    .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "") // Remove control characters
     .trim()
     .slice(0, 200); // Limit length to prevent abuse
 }
@@ -114,20 +117,22 @@ function parseFrontmatter(content: string): {
 
   try {
     // Simple YAML-like parsing for description with improved safety
-    const lines = frontmatter.split('\n');
+    const lines = frontmatter.split("\n");
     for (const line of lines) {
-      const colonIndex = line.indexOf(':');
+      const colonIndex = line.indexOf(":");
       if (colonIndex > 0) {
         const key = line.slice(0, colonIndex).trim();
         let value = line.slice(colonIndex + 1).trim();
 
         // Remove quotes if present
-        if ((value.startsWith('"') && value.endsWith('"')) ||
-            (value.startsWith("'") && value.endsWith("'"))) {
+        if (
+          (value.startsWith('"') && value.endsWith('"')) ||
+          (value.startsWith("'") && value.endsWith("'"))
+        ) {
           value = value.slice(1, -1);
         }
 
-        if (key === 'description' && value) {
+        if (key === "description" && value) {
           // Sanitize description for security
           data.description = sanitizeDescription(value);
         }
@@ -136,7 +141,7 @@ function parseFrontmatter(content: string): {
   } catch (error) {
     // If frontmatter parsing fails, log warning but continue
     const logger = getLogger();
-    logger.warn({ error, frontmatter }, 'Failed to parse frontmatter');
+    logger.warn({ error, frontmatter }, "Failed to parse frontmatter");
   }
 
   return { data, content: markdownContent };
@@ -154,7 +159,7 @@ export function clearCommandsCache(): void {
  * Check if cache is still valid
  */
 function isCacheValid(): boolean {
-  return commandsCache !== null && (Date.now() - cacheTimestamp) < CACHE_DURATION;
+  return commandsCache !== null && Date.now() - cacheTimestamp < CACHE_DURATION;
 }
 
 /**
@@ -165,12 +170,15 @@ export async function discoverClaudeCommands(): Promise<ClaudeCommand[]> {
 
   // Return cached commands if cache is still valid
   if (isCacheValid()) {
-    logger.debug({ cached: true, count: commandsCache!.length }, 'Using cached Claude commands');
+    logger.debug(
+      { cached: true, count: commandsCache!.length },
+      "Using cached Claude commands",
+    );
     return commandsCache!;
   }
 
   const workingDir = getWorkingDirectory();
-  const commandsDir = join(workingDir, '.claude', 'commands');
+  const commandsDir = join(workingDir, ".claude", "commands");
 
   try {
     const files = await readdir(commandsDir);
@@ -178,19 +186,19 @@ export async function discoverClaudeCommands(): Promise<ClaudeCommand[]> {
     const validationErrors: string[] = [];
 
     for (const file of files) {
-      if (extname(file) !== '.md') {
+      if (extname(file) !== ".md") {
         continue;
       }
 
       const filePath = join(commandsDir, file);
-      const commandName = basename(file, '.md');
+      const commandName = basename(file, ".md");
 
       // Validate command name
       const validation = validateCommandName(commandName);
       let command: ClaudeCommand;
 
       try {
-        const content = await readFile(filePath, 'utf-8');
+        const content = await readFile(filePath, "utf-8");
         const { data } = parseFrontmatter(content);
 
         command = {
@@ -207,30 +215,34 @@ export async function discoverClaudeCommands(): Promise<ClaudeCommand[]> {
         if (validation.isValid) {
           logger.debug(
             { commandName, description: data.description },
-            'Discovered valid Claude command',
+            "Discovered valid Claude command",
           );
         } else {
           validationErrors.push(validation.error!);
           logger.warn(
             { commandName, error: validation.error },
-            'Discovered invalid Claude command',
+            "Discovered invalid Claude command",
           );
         }
       } catch (error) {
-        logger.warn({ file, error }, 'Failed to read Claude command file');
+        logger.warn({ file, error }, "Failed to read Claude command file");
       }
     }
 
     // Log summary with validation results
-    const validCommands = commands.filter(cmd => cmd.isValid);
-    const invalidCommands = commands.filter(cmd => !cmd.isValid);
+    const validCommands = commands.filter((cmd) => cmd.isValid);
+    const invalidCommands = commands.filter((cmd) => !cmd.isValid);
 
-    logger.info({
-      total: commands.length,
-      valid: validCommands.length,
-      invalid: invalidCommands.length,
-      validationErrors: validationErrors.length > 0 ? validationErrors : undefined,
-    }, 'Discovered Claude commands with validation');
+    logger.info(
+      {
+        total: commands.length,
+        valid: validCommands.length,
+        invalid: invalidCommands.length,
+        validationErrors:
+          validationErrors.length > 0 ? validationErrors : undefined,
+      },
+      "Discovered Claude commands with validation",
+    );
 
     // Cache the results
     commandsCache = commands;
@@ -239,7 +251,7 @@ export async function discoverClaudeCommands(): Promise<ClaudeCommand[]> {
     return commands;
   } catch (error) {
     // Commands directory doesn't exist or isn't accessible
-    logger.debug({ commandsDir, error }, 'No Claude commands directory found');
+    logger.debug({ commandsDir, error }, "No Claude commands directory found");
 
     // Cache empty result to avoid repeated filesystem attempts
     commandsCache = [];
@@ -254,7 +266,7 @@ export async function discoverClaudeCommands(): Promise<ClaudeCommand[]> {
  */
 export async function getValidClaudeCommands(): Promise<ClaudeCommand[]> {
   const allCommands = await discoverClaudeCommands();
-  return allCommands.filter(cmd => cmd.isValid);
+  return allCommands.filter((cmd) => cmd.isValid);
 }
 
 /**
@@ -281,9 +293,11 @@ export async function getValidClaudeCommand(
 /**
  * Get command validation errors for debugging
  */
-export async function getCommandValidationErrors(): Promise<Array<{ name: string; error: string }>> {
+export async function getCommandValidationErrors(): Promise<
+  Array<{ name: string; error: string }>
+> {
   const commands = await discoverClaudeCommands();
   return commands
-    .filter(cmd => !cmd.isValid)
-    .map(cmd => ({ name: cmd.name, error: cmd.validationError! }));
+    .filter((cmd) => !cmd.isValid)
+    .map((cmd) => ({ name: cmd.name, error: cmd.validationError! }));
 }

--- a/src/claude/commands.improved.ts
+++ b/src/claude/commands.improved.ts
@@ -1,0 +1,289 @@
+import { readdir, readFile } from "node:fs/promises";
+import { basename, extname, join } from "node:path";
+import { getWorkingDirectory } from "../config.js";
+import { getLogger } from "../logger.js";
+
+export interface ClaudeCommand {
+  /** Command name (filename without .md) */
+  name: string;
+  /** Full file path */
+  filePath: string;
+  /** Description from frontmatter */
+  description?: string;
+  /** Raw command content */
+  content: string;
+  /** Whether command name is valid (doesn't conflict with built-ins) */
+  isValid: boolean;
+  /** Validation error message if invalid */
+  validationError?: string;
+}
+
+// Cache for discovered commands to avoid repeated filesystem operations
+let commandsCache: ClaudeCommand[] | null = null;
+let cacheTimestamp = 0;
+const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes in milliseconds
+
+// Built-in Telegram bot commands that should not be overridden
+const BUILT_IN_COMMANDS = new Set([
+  'start',
+  'help',
+  'clear',
+  'stop',
+  'restart',
+  'settings',
+  'version',
+  'status',
+  'ping',
+  'cancel',
+]);
+
+/**
+ * Validate command name to prevent conflicts and security issues
+ */
+function validateCommandName(name: string): { isValid: boolean; error?: string } {
+  // Check for built-in command conflicts
+  if (BUILT_IN_COMMANDS.has(name)) {
+    return {
+      isValid: false,
+      error: `Command '${name}' conflicts with built-in command`,
+    };
+  }
+
+  // Check for valid characters (alphanumeric, hyphens, underscores, dots)
+  if (!/^[a-zA-Z0-9_.-]+$/.test(name)) {
+    return {
+      isValid: false,
+      error: `Command '${name}' contains invalid characters. Use only letters, numbers, hyphens, underscores, and dots.`,
+    };
+  }
+
+  // Check reasonable length limits
+  if (name.length < 1) {
+    return {
+      isValid: false,
+      error: 'Command name cannot be empty',
+    };
+  }
+
+  if (name.length > 64) {
+    return {
+      isValid: false,
+      error: `Command '${name}' is too long (max 64 characters)`,
+    };
+  }
+
+  // Prevent command names that start/end with special chars
+  if (/^[._-]|[._-]$/.test(name)) {
+    return {
+      isValid: false,
+      error: `Command '${name}' cannot start or end with dots, hyphens, or underscores`,
+    };
+  }
+
+  return { isValid: true };
+}
+
+/**
+ * Sanitize description text to prevent injection attacks
+ */
+function sanitizeDescription(description: string): string {
+  // Remove or escape potentially dangerous characters
+  return description
+    .replace(/[<>]/g, '') // Remove HTML-like brackets
+    .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '') // Remove control characters
+    .trim()
+    .slice(0, 200); // Limit length to prevent abuse
+}
+
+/**
+ * Parse frontmatter from a markdown file with improved error handling
+ */
+function parseFrontmatter(content: string): {
+  data: Record<string, any>;
+  content: string;
+} {
+  const frontmatterRegex = /^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/;
+  const match = content.match(frontmatterRegex);
+
+  if (!match) {
+    return { data: {}, content };
+  }
+
+  const [, frontmatter, markdownContent] = match;
+  const data: Record<string, any> = {};
+
+  try {
+    // Simple YAML-like parsing for description with improved safety
+    const lines = frontmatter.split('\n');
+    for (const line of lines) {
+      const colonIndex = line.indexOf(':');
+      if (colonIndex > 0) {
+        const key = line.slice(0, colonIndex).trim();
+        let value = line.slice(colonIndex + 1).trim();
+
+        // Remove quotes if present
+        if ((value.startsWith('"') && value.endsWith('"')) ||
+            (value.startsWith("'") && value.endsWith("'"))) {
+          value = value.slice(1, -1);
+        }
+
+        if (key === 'description' && value) {
+          // Sanitize description for security
+          data.description = sanitizeDescription(value);
+        }
+      }
+    }
+  } catch (error) {
+    // If frontmatter parsing fails, log warning but continue
+    const logger = getLogger();
+    logger.warn({ error, frontmatter }, 'Failed to parse frontmatter');
+  }
+
+  return { data, content: markdownContent };
+}
+
+/**
+ * Clear the commands cache (useful for testing or when commands change)
+ */
+export function clearCommandsCache(): void {
+  commandsCache = null;
+  cacheTimestamp = 0;
+}
+
+/**
+ * Check if cache is still valid
+ */
+function isCacheValid(): boolean {
+  return commandsCache !== null && (Date.now() - cacheTimestamp) < CACHE_DURATION;
+}
+
+/**
+ * Discover all Claude commands in the working directory with caching and validation
+ */
+export async function discoverClaudeCommands(): Promise<ClaudeCommand[]> {
+  const logger = getLogger();
+
+  // Return cached commands if cache is still valid
+  if (isCacheValid()) {
+    logger.debug({ cached: true, count: commandsCache!.length }, 'Using cached Claude commands');
+    return commandsCache!;
+  }
+
+  const workingDir = getWorkingDirectory();
+  const commandsDir = join(workingDir, '.claude', 'commands');
+
+  try {
+    const files = await readdir(commandsDir);
+    const commands: ClaudeCommand[] = [];
+    const validationErrors: string[] = [];
+
+    for (const file of files) {
+      if (extname(file) !== '.md') {
+        continue;
+      }
+
+      const filePath = join(commandsDir, file);
+      const commandName = basename(file, '.md');
+
+      // Validate command name
+      const validation = validateCommandName(commandName);
+      let command: ClaudeCommand;
+
+      try {
+        const content = await readFile(filePath, 'utf-8');
+        const { data } = parseFrontmatter(content);
+
+        command = {
+          name: commandName,
+          filePath,
+          description: data.description,
+          content,
+          isValid: validation.isValid,
+          validationError: validation.error,
+        };
+
+        commands.push(command);
+
+        if (validation.isValid) {
+          logger.debug(
+            { commandName, description: data.description },
+            'Discovered valid Claude command',
+          );
+        } else {
+          validationErrors.push(validation.error!);
+          logger.warn(
+            { commandName, error: validation.error },
+            'Discovered invalid Claude command',
+          );
+        }
+      } catch (error) {
+        logger.warn({ file, error }, 'Failed to read Claude command file');
+      }
+    }
+
+    // Log summary with validation results
+    const validCommands = commands.filter(cmd => cmd.isValid);
+    const invalidCommands = commands.filter(cmd => !cmd.isValid);
+
+    logger.info({
+      total: commands.length,
+      valid: validCommands.length,
+      invalid: invalidCommands.length,
+      validationErrors: validationErrors.length > 0 ? validationErrors : undefined,
+    }, 'Discovered Claude commands with validation');
+
+    // Cache the results
+    commandsCache = commands;
+    cacheTimestamp = Date.now();
+
+    return commands;
+  } catch (error) {
+    // Commands directory doesn't exist or isn't accessible
+    logger.debug({ commandsDir, error }, 'No Claude commands directory found');
+
+    // Cache empty result to avoid repeated filesystem attempts
+    commandsCache = [];
+    cacheTimestamp = Date.now();
+
+    return [];
+  }
+}
+
+/**
+ * Get valid Claude commands only (filtering out invalid ones)
+ */
+export async function getValidClaudeCommands(): Promise<ClaudeCommand[]> {
+  const allCommands = await discoverClaudeCommands();
+  return allCommands.filter(cmd => cmd.isValid);
+}
+
+/**
+ * Get a specific Claude command by name with caching
+ */
+export async function getClaudeCommand(
+  commandName: string,
+): Promise<ClaudeCommand | null> {
+  // Use cached commands for lookup to avoid repeated filesystem operations
+  const commands = await discoverClaudeCommands();
+  return commands.find((cmd) => cmd.name === commandName) || null;
+}
+
+/**
+ * Get a specific valid Claude command by name
+ */
+export async function getValidClaudeCommand(
+  commandName: string,
+): Promise<ClaudeCommand | null> {
+  const command = await getClaudeCommand(commandName);
+  return command && command.isValid ? command : null;
+}
+
+/**
+ * Get command validation errors for debugging
+ */
+export async function getCommandValidationErrors(): Promise<Array<{ name: string; error: string }>> {
+  const commands = await discoverClaudeCommands();
+  return commands
+    .filter(cmd => !cmd.isValid)
+    .map(cmd => ({ name: cmd.name, error: cmd.validationError! }));
+}

--- a/src/claude/commands.improved.ts
+++ b/src/claude/commands.improved.ts
@@ -93,7 +93,19 @@ function sanitizeDescription(description: string): string {
   // Remove or escape potentially dangerous characters
   return description
     .replace(/[<>]/g, "") // Remove HTML-like brackets
-    .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "") // Remove control characters
+    .split("")
+    .filter((char) => {
+      const code = char.charCodeAt(0);
+      // Remove control characters (0-8, 11, 12, 14-31, 127)
+      return !(
+        code <= 8 ||
+        code === 11 ||
+        code === 12 ||
+        (code >= 14 && code <= 31) ||
+        code === 127
+      );
+    })
+    .join("")
     .trim()
     .slice(0, 200); // Limit length to prevent abuse
 }
@@ -102,7 +114,7 @@ function sanitizeDescription(description: string): string {
  * Parse frontmatter from a markdown file with improved error handling
  */
 function parseFrontmatter(content: string): {
-  data: Record<string, any>;
+  data: Record<string, unknown>;
   content: string;
 } {
   const frontmatterRegex = /^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/;
@@ -113,7 +125,7 @@ function parseFrontmatter(content: string): {
   }
 
   const [, frontmatter, markdownContent] = match;
-  const data: Record<string, any> = {};
+  const data: Record<string, unknown> = {};
 
   try {
     // Simple YAML-like parsing for description with improved safety
@@ -204,7 +216,8 @@ export async function discoverClaudeCommands(): Promise<ClaudeCommand[]> {
         command = {
           name: commandName,
           filePath,
-          description: data.description,
+          description:
+            typeof data.description === "string" ? data.description : undefined,
           content,
           isValid: validation.isValid,
           validationError: validation.error,

--- a/src/claude/commands.improved.ts
+++ b/src/claude/commands.improved.ts
@@ -287,7 +287,7 @@ export async function getValidClaudeCommand(
   commandName: string,
 ): Promise<ClaudeCommand | null> {
   const command = await getClaudeCommand(commandName);
-  return command && command.isValid ? command : null;
+  return command?.isValid ? command : null;
 }
 
 /**

--- a/src/claude/commands.ts
+++ b/src/claude/commands.ts
@@ -6,12 +6,7 @@ import { getLogger } from "../logger.js";
 /**
  * Built-in Telegram bot commands that cannot be overridden
  */
-const RESERVED_COMMANDS = new Set([
-  'start',
-  'help',
-  'clear',
-  'dynamic'
-]);
+const RESERVED_COMMANDS = new Set(["start", "help", "clear", "dynamic"]);
 
 /**
  * Cache for discovered commands to improve performance
@@ -38,7 +33,7 @@ function validateCommandName(commandName: string, logger: any): boolean {
   if (RESERVED_COMMANDS.has(commandName)) {
     logger.warn(
       { commandName, reserved: Array.from(RESERVED_COMMANDS) },
-      `Skipping Claude command '${commandName}' - conflicts with built-in command`
+      `Skipping Claude command '${commandName}' - conflicts with built-in command`,
     );
     return false;
   }
@@ -47,7 +42,7 @@ function validateCommandName(commandName: string, logger: any): boolean {
   if (!/^[a-zA-Z0-9._-]+$/.test(commandName)) {
     logger.warn(
       { commandName },
-      `Skipping Claude command '${commandName}' - invalid command name format`
+      `Skipping Claude command '${commandName}' - invalid command name format`,
     );
     return false;
   }
@@ -58,7 +53,10 @@ function validateCommandName(commandName: string, logger: any): boolean {
 /**
  * Parse frontmatter from a markdown file
  */
-function parseFrontmatter(content: string, logger: any): {
+function parseFrontmatter(
+  content: string,
+  logger: any,
+): {
   data: Record<string, any>;
   content: string;
   warnings?: string[];
@@ -110,13 +108,22 @@ function parseFrontmatter(content: string, logger: any): {
 /**
  * Discover all Claude commands in the working directory
  */
-export async function discoverClaudeCommands(forceRefresh = false): Promise<ClaudeCommand[]> {
+export async function discoverClaudeCommands(
+  forceRefresh = false,
+): Promise<ClaudeCommand[]> {
   const logger = getLogger();
 
   // Check cache validity
   const now = Date.now();
-  if (!forceRefresh && commandCache !== null && (now - cacheTimestamp) < CACHE_TTL) {
-    logger.debug({ cacheAge: now - cacheTimestamp }, "Using cached Claude commands");
+  if (
+    !forceRefresh &&
+    commandCache !== null &&
+    now - cacheTimestamp < CACHE_TTL
+  ) {
+    logger.debug(
+      { cacheAge: now - cacheTimestamp },
+      "Using cached Claude commands",
+    );
     return commandCache;
   }
 

--- a/src/claude/commands.ts
+++ b/src/claude/commands.ts
@@ -29,7 +29,10 @@ export interface ClaudeCommand {
 /**
  * Validate that a command name doesn't conflict with built-in commands
  */
-function validateCommandName(commandName: string, logger: any): boolean {
+function validateCommandName(
+  commandName: string,
+  logger: ReturnType<typeof import("../logger.js").getLogger>,
+): boolean {
   if (RESERVED_COMMANDS.has(commandName)) {
     logger.warn(
       { commandName, reserved: Array.from(RESERVED_COMMANDS) },
@@ -55,9 +58,9 @@ function validateCommandName(commandName: string, logger: any): boolean {
  */
 function parseFrontmatter(
   content: string,
-  logger: any,
+  logger: ReturnType<typeof import("../logger.js").getLogger>,
 ): {
-  data: Record<string, any>;
+  data: Record<string, unknown>;
   content: string;
   warnings?: string[];
 } {
@@ -69,7 +72,7 @@ function parseFrontmatter(
   }
 
   const [, frontmatter, markdownContent] = match;
-  const data: Record<string, any> = {};
+  const data: Record<string, unknown> = {};
   const warnings: string[] = [];
 
   try {
@@ -149,12 +152,13 @@ export async function discoverClaudeCommands(
 
       try {
         const content = await readFile(filePath, "utf-8");
-        const { data, warnings } = parseFrontmatter(content, logger);
+        const { data, warnings: _warnings } = parseFrontmatter(content, logger);
 
         commands.push({
           name: commandName,
           filePath,
-          description: data.description,
+          description:
+            typeof data.description === "string" ? data.description : undefined,
           content,
         });
 

--- a/src/claude/commands.ts
+++ b/src/claude/commands.ts
@@ -1,0 +1,107 @@
+import { readdir, readFile } from "node:fs/promises";
+import { basename, extname, join } from "node:path";
+import { getWorkingDirectory } from "../config.js";
+import { getLogger } from "../logger.js";
+
+export interface ClaudeCommand {
+  /** Command name (filename without .md) */
+  name: string;
+  /** Full file path */
+  filePath: string;
+  /** Description from frontmatter */
+  description?: string;
+  /** Raw command content */
+  content: string;
+}
+
+/**
+ * Parse frontmatter from a markdown file
+ */
+function parseFrontmatter(content: string): {
+  data: Record<string, any>;
+  content: string;
+} {
+  const frontmatterRegex = /^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/;
+  const match = content.match(frontmatterRegex);
+
+  if (!match) {
+    return { data: {}, content };
+  }
+
+  const [, frontmatter, markdownContent] = match;
+  const data: Record<string, any> = {};
+
+  // Simple YAML-like parsing for description
+  const lines = frontmatter.split("\n");
+  for (const line of lines) {
+    const colonIndex = line.indexOf(":");
+    if (colonIndex > 0) {
+      const key = line.slice(0, colonIndex).trim();
+      const value = line.slice(colonIndex + 1).trim();
+      if (key === "description" && value) {
+        data.description = value;
+      }
+    }
+  }
+
+  return { data, content: markdownContent };
+}
+
+/**
+ * Discover all Claude commands in the working directory
+ */
+export async function discoverClaudeCommands(): Promise<ClaudeCommand[]> {
+  const logger = getLogger();
+  const workingDir = getWorkingDirectory();
+  const commandsDir = join(workingDir, ".claude", "commands");
+
+  try {
+    const files = await readdir(commandsDir);
+    const commands: ClaudeCommand[] = [];
+
+    for (const file of files) {
+      if (extname(file) !== ".md") {
+        continue;
+      }
+
+      const filePath = join(commandsDir, file);
+      const commandName = basename(file, ".md");
+
+      try {
+        const content = await readFile(filePath, "utf-8");
+        const { data } = parseFrontmatter(content);
+
+        commands.push({
+          name: commandName,
+          filePath,
+          description: data.description,
+          content,
+        });
+
+        logger.debug(
+          { commandName, description: data.description },
+          "Discovered Claude command",
+        );
+      } catch (error) {
+        logger.warn({ file, error }, "Failed to read Claude command file");
+      }
+    }
+
+    logger.info({ count: commands.length }, "Discovered Claude commands");
+    return commands;
+  } catch (error) {
+    // Commands directory doesn't exist or isn't accessible
+    logger.debug({ commandsDir, error }, "No Claude commands directory found");
+    return [];
+  }
+}
+
+/**
+ * Get a specific Claude command by name
+ */
+export async function getClaudeCommand(
+  commandName: string,
+): Promise<ClaudeCommand | null> {
+  const commands = await discoverClaudeCommands();
+  return commands.find((cmd) => cmd.name === commandName) || null;
+}

--- a/src/claude/commands.ts
+++ b/src/claude/commands.ts
@@ -3,6 +3,23 @@ import { basename, extname, join } from "node:path";
 import { getWorkingDirectory } from "../config.js";
 import { getLogger } from "../logger.js";
 
+/**
+ * Built-in Telegram bot commands that cannot be overridden
+ */
+const RESERVED_COMMANDS = new Set([
+  'start',
+  'help',
+  'clear',
+  'dynamic'
+]);
+
+/**
+ * Cache for discovered commands to improve performance
+ */
+let commandCache: ClaudeCommand[] | null = null;
+let cacheTimestamp: number = 0;
+const CACHE_TTL = 5 * 60 * 1000; // 5 minutes in milliseconds
+
 export interface ClaudeCommand {
   /** Command name (filename without .md) */
   name: string;
@@ -15,11 +32,36 @@ export interface ClaudeCommand {
 }
 
 /**
+ * Validate that a command name doesn't conflict with built-in commands
+ */
+function validateCommandName(commandName: string, logger: any): boolean {
+  if (RESERVED_COMMANDS.has(commandName)) {
+    logger.warn(
+      { commandName, reserved: Array.from(RESERVED_COMMANDS) },
+      `Skipping Claude command '${commandName}' - conflicts with built-in command`
+    );
+    return false;
+  }
+
+  // Additional validation for command name format
+  if (!/^[a-zA-Z0-9._-]+$/.test(commandName)) {
+    logger.warn(
+      { commandName },
+      `Skipping Claude command '${commandName}' - invalid command name format`
+    );
+    return false;
+  }
+
+  return true;
+}
+
+/**
  * Parse frontmatter from a markdown file
  */
-function parseFrontmatter(content: string): {
+function parseFrontmatter(content: string, logger: any): {
   data: Record<string, any>;
   content: string;
+  warnings?: string[];
 } {
   const frontmatterRegex = /^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/;
   const match = content.match(frontmatterRegex);
@@ -30,28 +72,54 @@ function parseFrontmatter(content: string): {
 
   const [, frontmatter, markdownContent] = match;
   const data: Record<string, any> = {};
+  const warnings: string[] = [];
 
-  // Simple YAML-like parsing for description
-  const lines = frontmatter.split("\n");
-  for (const line of lines) {
-    const colonIndex = line.indexOf(":");
-    if (colonIndex > 0) {
-      const key = line.slice(0, colonIndex).trim();
-      const value = line.slice(colonIndex + 1).trim();
-      if (key === "description" && value) {
-        data.description = value;
+  try {
+    // Simple YAML-like parsing for description
+    const lines = frontmatter.split("\n");
+    for (const line of lines) {
+      const colonIndex = line.indexOf(":");
+      if (colonIndex > 0) {
+        const key = line.slice(0, colonIndex).trim();
+        const value = line.slice(colonIndex + 1).trim();
+        if (key === "description" && value) {
+          // Remove quotes if present
+          const cleanValue = value.replace(/^["']|["']$/g, "");
+          if (cleanValue.length === 0) {
+            warnings.push("Empty description found");
+          } else if (cleanValue.length > 200) {
+            warnings.push("Description is very long (>200 chars)");
+          } else {
+            data.description = cleanValue;
+          }
+        }
       }
     }
+  } catch (error) {
+    logger.warn({ error }, "Error parsing frontmatter");
+    warnings.push("Failed to parse frontmatter");
   }
 
-  return { data, content: markdownContent };
+  if (warnings.length > 0) {
+    logger.debug({ warnings }, "Frontmatter parsing warnings");
+  }
+
+  return { data, content: markdownContent, warnings };
 }
 
 /**
  * Discover all Claude commands in the working directory
  */
-export async function discoverClaudeCommands(): Promise<ClaudeCommand[]> {
+export async function discoverClaudeCommands(forceRefresh = false): Promise<ClaudeCommand[]> {
   const logger = getLogger();
+
+  // Check cache validity
+  const now = Date.now();
+  if (!forceRefresh && commandCache !== null && (now - cacheTimestamp) < CACHE_TTL) {
+    logger.debug({ cacheAge: now - cacheTimestamp }, "Using cached Claude commands");
+    return commandCache;
+  }
+
   const workingDir = getWorkingDirectory();
   const commandsDir = join(workingDir, ".claude", "commands");
 
@@ -67,9 +135,14 @@ export async function discoverClaudeCommands(): Promise<ClaudeCommand[]> {
       const filePath = join(commandsDir, file);
       const commandName = basename(file, ".md");
 
+      // Validate command name before processing
+      if (!validateCommandName(commandName, logger)) {
+        continue;
+      }
+
       try {
         const content = await readFile(filePath, "utf-8");
-        const { data } = parseFrontmatter(content);
+        const { data, warnings } = parseFrontmatter(content, logger);
 
         commands.push({
           name: commandName,
@@ -87,13 +160,36 @@ export async function discoverClaudeCommands(): Promise<ClaudeCommand[]> {
       }
     }
 
+    // Update cache
+    commandCache = commands;
+    cacheTimestamp = now;
+
     logger.info({ count: commands.length }, "Discovered Claude commands");
     return commands;
   } catch (error) {
     // Commands directory doesn't exist or isn't accessible
     logger.debug({ commandsDir, error }, "No Claude commands directory found");
+
+    // Cache empty result to avoid repeated filesystem checks
+    commandCache = [];
+    cacheTimestamp = now;
     return [];
   }
+}
+
+/**
+ * Clear the command cache (useful for testing or manual refresh)
+ */
+export function clearCommandCache(): void {
+  commandCache = null;
+  cacheTimestamp = 0;
+}
+
+/**
+ * Get the list of reserved command names
+ */
+export function getReservedCommands(): string[] {
+  return Array.from(RESERVED_COMMANDS);
 }
 
 /**

--- a/src/claude/executor.ts
+++ b/src/claude/executor.ts
@@ -8,6 +8,7 @@ export interface ExecuteOptions {
   downloadsPath?: string;
   sessionId?: string | null;
   onProgress?: (message: string) => void;
+  messageTimestamp?: number;
 }
 
 export interface ExecuteResult {
@@ -23,12 +24,24 @@ export interface ExecuteResult {
 export async function executeClaudeQuery(
   options: ExecuteOptions,
 ): Promise<ExecuteResult> {
-  const { prompt, downloadsPath, sessionId, onProgress } = options;
+  const { prompt, downloadsPath, sessionId, onProgress, messageTimestamp } = options;
   const logger = getLogger();
 
-  // Append downloads path info to prompt if provided
-  const fullPrompt = downloadsPath
-    ? `${prompt}\n\n[System: To send files to the user, write them to: ${downloadsPath}]`
+  // Build system context with downloads path and timestamp
+  const systemContext: string[] = [];
+
+  if (downloadsPath) {
+    systemContext.push(`To send files to the user, write them to: ${downloadsPath}`);
+  }
+
+  if (messageTimestamp) {
+    const messageDate = new Date(messageTimestamp * 1000);
+    const isoString = messageDate.toISOString();
+    systemContext.push(`Message timestamp: ${isoString} (${messageTimestamp})`);
+  }
+
+  const fullPrompt = systemContext.length > 0
+    ? `${prompt}\n\n[System: ${systemContext.join(" | ")}]`
     : prompt;
 
   const args: string[] = [

--- a/src/claude/executor.ts
+++ b/src/claude/executor.ts
@@ -24,14 +24,17 @@ export interface ExecuteResult {
 export async function executeClaudeQuery(
   options: ExecuteOptions,
 ): Promise<ExecuteResult> {
-  const { prompt, downloadsPath, sessionId, onProgress, messageTimestamp } = options;
+  const { prompt, downloadsPath, sessionId, onProgress, messageTimestamp } =
+    options;
   const logger = getLogger();
 
   // Build system context with downloads path and timestamp
   const systemContext: string[] = [];
 
   if (downloadsPath) {
-    systemContext.push(`To send files to the user, write them to: ${downloadsPath}`);
+    systemContext.push(
+      `To send files to the user, write them to: ${downloadsPath}`,
+    );
   }
 
   if (messageTimestamp) {
@@ -40,9 +43,10 @@ export async function executeClaudeQuery(
     systemContext.push(`Message timestamp: ${isoString} (${messageTimestamp})`);
   }
 
-  const fullPrompt = systemContext.length > 0
-    ? `${prompt}\n\n[System: ${systemContext.join(" | ")}]`
-    : prompt;
+  const fullPrompt =
+    systemContext.length > 0
+      ? `${prompt}\n\n[System: ${systemContext.join(" | ")}]`
+      : prompt;
 
   const args: string[] = [
     "-p",

--- a/test-command-discovery.js
+++ b/test-command-discovery.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+import { join } from 'path';
+import { discoverClaudeCommands } from './dist/claude/commands.js';
+
+// Set working directory to examples/basic for testing
+const testDir = join(process.cwd(), 'examples', 'basic');
+process.chdir(testDir);
+
+console.log('Testing command discovery...');
+console.log('Working directory:', process.cwd());
+
+try {
+  const commands = await discoverClaudeCommands();
+  console.log('\n✅ Command discovery successful!');
+  console.log(`Found ${commands.length} commands:`);
+
+  for (const command of commands) {
+    console.log(`  - /${command.name}: ${command.description || 'No description'}`);
+  }
+
+  if (commands.length > 0) {
+    console.log('\n✅ Manual Testing: Command discovery works correctly');
+  } else {
+    console.log('\n⚠️  Manual Testing: No commands found (expected at least test-command)');
+  }
+} catch (error) {
+  console.error('\n❌ Command discovery failed:', error.message);
+  process.exit(1);
+}

--- a/test-command-discovery.ts
+++ b/test-command-discovery.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env tsx
+
+import { join } from 'path';
+import { discoverClaudeCommands } from './src/claude/commands.js';
+import { initConfig, getWorkingDirectory } from './src/config.js';
+
+// Set working directory to examples/basic for testing
+const testDir = join(process.cwd(), 'examples', 'basic');
+initConfig(testDir);
+
+console.log('Testing command discovery...');
+console.log('Working directory:', getWorkingDirectory());
+
+try {
+  const commands = await discoverClaudeCommands();
+  console.log('\n✅ Command discovery successful!');
+  console.log(`Found ${commands.length} commands:`);
+
+  for (const command of commands) {
+    console.log(`  - /${command.name}: ${command.description || 'No description'}`);
+  }
+
+  if (commands.length > 0) {
+    console.log('\n✅ Manual Testing: Command discovery works correctly');
+  } else {
+    console.log('\n⚠️  Manual Testing: No commands found (expected at least test-command)');
+  }
+} catch (error) {
+  console.error('\n❌ Command discovery failed:', error.message);
+  process.exit(1);
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    clearMocks: true,
+    mockReset: true,
+    restoreMocks: true,
+    include: ['src/**/*.test.ts', 'tests/**/*.test.ts'],
+    exclude: ['node_modules', 'dist', 'examples'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      exclude: [
+        'node_modules/**',
+        'dist/**',
+        'examples/**',
+        '**/*.test.ts',
+        '**/*.config.ts',
+        'src/cli.ts', // CLI entry point
+        'src/index.ts' // Library entry point
+      ]
+    }
+  },
+  resolve: {
+    alias: {
+      '@': './src'
+    }
+  }
+});


### PR DESCRIPTION
## Summary
Implements Issue #6 - Dynamic mapping of Telegram  to Claude Code slash commands from  files.

## Problem Solved
Previously, the Telegram bot only supported hardcoded built-in commands (, , ). Users couldn't access Claude Code's powerful slash command system through Telegram.

## Solution
This PR adds automatic discovery and registration of Claude commands, making them available as Telegram commands.

## Key Features

### 🔍 **Automatic Discovery**
- Scans  files in the working directory
- Parses frontmatter to extract command descriptions
- Dynamically registers discovered commands with the Telegram bot

### ⚡ **Seamless Execution**
-  in Telegram →  in Claude Code
- Full integration with existing user session management
- Supports file uploads/downloads, progress tracking, and error handling

### 📚 **Enhanced Help System**
- Built-in commands and Claude commands shown separately in 
- Command descriptions automatically extracted from frontmatter
- Clear categorization for better user experience

## Technical Implementation

### New Files
-  - Command discovery and frontmatter parsing
-  - Execution handler for Claude commands  
-  - Dynamic command registration system

### Updated Files
-  - Register dynamic commands on startup
-  - Show discovered commands in help

## Usage Examples

**Before:**


**After (with Claude commands):**


**Command Execution:**


## Testing
- ✅ TypeScript compilation passes
- ✅ All linting checks pass
- ✅ Build completes successfully
- ✅ Integration with existing user/session management verified
- ✅ Error handling for missing commands and execution failures

## Configuration
No configuration changes required - feature works automatically when:
1.  directory exists in working directory
2. Commands are valid  files with proper frontmatter

## Backward Compatibility
- ✅ All existing built-in commands continue to work unchanged
- ✅ No breaking changes to existing functionality
- ✅ Graceful degradation when no Claude commands are found

Closes #6